### PR TITLE
fix: standardise type of date/time object in the codebase

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -6,7 +6,6 @@ import useCases.AdminManager;
 
 import java.time.DayOfWeek;
 import java.time.LocalTime;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,7 +16,7 @@ public class Main {
             return;
         }
 
-        database.setClinic(new Clinic("", "", "", "", ZoneId.of("US/Eastern"),
+        database.setClinic(new Clinic("", "", "", "",
                 new ArrayList<>(List.of(new Availability(DayOfWeek.of(1), LocalTime.of(8, 30),
                                 LocalTime.of(17, 0)),
                         new Availability(DayOfWeek.of(2), LocalTime.of(8, 30),

--- a/src/controllers/DoctorController.java
+++ b/src/controllers/DoctorController.java
@@ -121,8 +121,8 @@ public class DoctorController extends UserController<Doctor> {
         return (x) -> {
             ArrayList<Integer> absenceData = doctorScreenView.addAbsencePrompt();
             new AppointmentManager(getDatabase()).addAbsence(doctorData, new TimeUtils()
-                    .createZonedDataTime(absenceData.get(0), absenceData.get(1),
-                    absenceData.get(2), 0, 0), new TimeUtils().createZonedDataTime(absenceData.get(0),
+                    .createLocalDateTime(absenceData.get(0), absenceData.get(1),
+                    absenceData.get(2), 0, 0), new TimeUtils().createLocalDataTime(absenceData.get(0),
                     absenceData.get(1), absenceData.get(2) + absenceData.get(3), 0, 0));
         };
     } */

--- a/src/controllers/SecretaryController.java
+++ b/src/controllers/SecretaryController.java
@@ -148,8 +148,8 @@ public class SecretaryController extends UserController<Secretary> {
             String doctor = secretaryScreenView.getTargetDoctor();
             DoctorData doctorData = doctorManager.getUserData(doctor);
 
-            appointmentManager.addAbsence(doctorData, secretaryScreenView.addZoneDateTimeStart(),
-                    secretaryScreenView.addZoneDateTimeEnd());
+            appointmentManager.addAbsence(doctorData, secretaryScreenView.addLocalDateTimeStart(),
+                    secretaryScreenView.addLocalDateTimeEnd());
         };
     } */
 

--- a/src/dataBundles/ClinicData.java
+++ b/src/dataBundles/ClinicData.java
@@ -2,7 +2,6 @@ package dataBundles;
 
 import entities.Clinic;
 
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.stream.Collectors;
 
@@ -33,13 +32,6 @@ public class ClinicData {
      */
     public String getEmail(){
         return clinic.getEmail();
-    }
-
-    /**
-     * @return ZoneId - timezone of the clinic stored.
-     */
-    public ZoneId getTimeZone() {
-        return clinic.getTimeZone();
     }
 
     /**

--- a/src/dataBundles/PrescriptionData.java
+++ b/src/dataBundles/PrescriptionData.java
@@ -2,7 +2,8 @@ package dataBundles;
 
 import entities.Prescription;
 
-import java.time.ZonedDateTime;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 /**
  * Wrapper class for Prescription entity.
@@ -20,16 +21,16 @@ public class PrescriptionData {
     }
 
     /**
-     * @return ZonedDateTime - date the prescription stored was created.
+     * @return LocalDate - date the prescription stored was created.
      */
-    public ZonedDateTime getDateNoted() {
+    public LocalDate getDateNoted() {
         return prescription.getDateNoted();
     }
 
     /**
-     * @return ZonedDateTime - expiry date of the prescription stored.
+     * @return LocalDate - expiry date of the prescription stored.
      */
-    public ZonedDateTime getExpiryDate() {
+    public LocalDate getExpiryDate() {
         return prescription.getExpiryDate();
     }
 

--- a/src/dataBundles/ReportData.java
+++ b/src/dataBundles/ReportData.java
@@ -4,7 +4,7 @@ package dataBundles;
 
 import entities.Report;
 
-import java.time.ZonedDateTime;
+import java.time.LocalDate;
 
 /**
  * Wrapper class for Report entity.
@@ -22,9 +22,9 @@ public class ReportData {
     }
 
     /**
-     * @return ZonedDateTime - date and time that the stored report was created.
+     * @return LocalDate - date that the stored report was created.
      */
-    public ZonedDateTime getDateNoted() {
+    public LocalDate getDateNoted() {
         return report.getDateNoted();
     }
 

--- a/src/dataBundles/TimeBlockData.java
+++ b/src/dataBundles/TimeBlockData.java
@@ -4,8 +4,8 @@ package dataBundles;
 
 import entities.TimeBlock;
 
+import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.ZonedDateTime;
 
 /**
  * Wrapper class for a TimeBlock entity.
@@ -23,16 +23,16 @@ public class TimeBlockData {
     }
 
     /**
-     * @return ZonedDateTime - start time of the time block.
+     * @return LocalDateTime - start time of the time block.
      */
-    public ZonedDateTime getStartTime(){
+    public LocalDateTime getStartTime(){
         return timeBlock.getStartTime();
     }
 
     /**
-     * @return ZonedDateTime - end time of the time block.
+     * @return LocalDateTime - end time of the time block.
      */
-    public ZonedDateTime getEndTime(){
+    public LocalDateTime getEndTime(){
         return timeBlock.getEndTime();
     }
 

--- a/src/database/JsonDatabase.java
+++ b/src/database/JsonDatabase.java
@@ -1,7 +1,6 @@
 package database;
 
 import com.fatboyindustrial.gsonjavatime.Converters;
-import com.fatboyindustrial.gsonjavatime.ZoneIdConverter;
 import com.google.gson.*;
 import utilities.JsonSerializable;
 
@@ -53,10 +52,6 @@ public class JsonDatabase<T extends JsonSerializable> implements DataMapperGatew
 
         GsonBuilder builder = Converters.registerAll(new GsonBuilder());
 
-        // Unfortunately, Google's Gson library implicitly serializes immutable private objects which causes the
-        // compiler to issue a runtime warning. This is a temporary fix for now, until I find a better library.
-        builder.registerTypeAdapter(getZoneRegionClass(), new ZoneIdConverter());
-
         this.gson = builder.create();
         this.database = new HashMap<>();
         this.keyDelegator = keyDelegator;
@@ -74,19 +69,6 @@ public class JsonDatabase<T extends JsonSerializable> implements DataMapperGatew
         try {
             return type.getMethod(name);
         } catch (NoSuchMethodException ignored) {
-            return null;
-        }
-    }
-
-    /**
-     * Gets ZoneRegion class by name.
-     * Used to initialize the Gson type adapter and avoid the serialization of immutable private object.
-     * @return ZoneRegion class by name.
-     */
-    private Class<?> getZoneRegionClass() {
-        try {
-            return Class.forName("java.time.ZoneRegion");
-        } catch (Exception ignored) {
             return null;
         }
     }

--- a/src/entities/Clinic.java
+++ b/src/entities/Clinic.java
@@ -2,7 +2,6 @@ package entities;
 
 import utilities.JsonSerializable;
 
-import java.time.ZoneId;
 import java.util.ArrayList;
 
 /**
@@ -14,8 +13,6 @@ public class Clinic extends JsonSerializable {
     private String phoneNumber;
     private String email;
     private String address;
-    private ZoneId timeZone;
-    //used to store the operating hours of the clinic for availability calculations
     private final ArrayList<Availability> clinicHours;
 
     /**
@@ -23,16 +20,13 @@ public class Clinic extends JsonSerializable {
      * @param name String representing the name of the clinic.
      * @param phoneNumber String representing the phone number of the clinic.
      * @param address String representing the address of the clinic.
-     * @param timeZone ZoneId representing the time zone of the clinic.
      * @param clinicHours TimeBlock representing the clinic's hours of operation.
      */
-    public Clinic(String name, String phoneNumber, String email, String address, ZoneId timeZone,
-                  ArrayList<Availability> clinicHours) {
+    public Clinic(String name, String phoneNumber, String email, String address, ArrayList<Availability> clinicHours) {
         this.name = name;
         this.phoneNumber = phoneNumber;
         this.email = email;
         this.address = address;
-        this.timeZone = timeZone;
         this.clinicHours = clinicHours;
     }
 
@@ -96,22 +90,7 @@ public class Clinic extends JsonSerializable {
         this.address = address;
     }
 
-    /**
-     * @return ZoneId representing the time zone of the clinic.
-     */
-    public ZoneId getTimeZone() {
-        return timeZone;
-    }
-
     // ALL CODE BELOW IS FOR PHASE 2
-
-    /**
-     * Sets the time zone of the clinic.
-     * @param timeZone The new time zone of the clinic as ZoneId.
-     */
-    public void setTimeZone(ZoneId timeZone) {
-        this.timeZone = timeZone;
-    }
 
     /**
      * @return TimeBlock representing the clinic's hours of operation.

--- a/src/entities/Note.java
+++ b/src/entities/Note.java
@@ -2,15 +2,14 @@ package entities;
 
 import utilities.JsonSerializable;
 
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.LocalDate;
 
 /**
  * Represents a note.
  */
 public abstract class Note extends JsonSerializable {
 
-    private final ZonedDateTime dateNoted = ZonedDateTime.now(ZoneId.of("US/Eastern"));
+    private final LocalDate dateNoted = LocalDate.now();
     private String header;
     private String body;
     private Integer patientId;
@@ -31,9 +30,9 @@ public abstract class Note extends JsonSerializable {
     }
 
     /**
-     * @return ZonedDateTime representing the date and time that the note was created.
+     * @return LocalDate representing the date that the note was created.
      */
-    public ZonedDateTime getDateNoted() {
+    public LocalDate getDateNoted() {
         return dateNoted;
     }
 

--- a/src/entities/Prescription.java
+++ b/src/entities/Prescription.java
@@ -1,13 +1,13 @@
 package entities;
 
-import java.time.ZonedDateTime;
+import java.time.LocalDate;
 
 /**
  * Represents a prescription.
  */
 public class Prescription extends Note {
 
-    private ZonedDateTime expiryDate;
+    private LocalDate expiryDate;
 
     /**
      * Creates an instance of Prescription.
@@ -15,26 +15,26 @@ public class Prescription extends Note {
      * @param body String representing the body of the prescription.
      * @param patientId Integer representing the id of the patient who the prescription was created for.
      * @param doctorId Integer representing the id of the doctor who created the prescription.
-     * @param expiryDate ZonedDateTime representing the prescription's expiry date.
+     * @param expiryDate LocalDate representing the prescription's expiry date.
      */
     public Prescription(String header, String body, Integer patientId, Integer doctorId,
-                        ZonedDateTime expiryDate) {
+                        LocalDate expiryDate) {
         super(header, body, patientId, doctorId);
         this.expiryDate = expiryDate;
     }
 
     /**
-     * @return ZonedDateTime representing the prescription's expiry date.
+     * @return LocalDate representing the prescription's expiry date.
      */
-    public ZonedDateTime getExpiryDate() {
+    public LocalDate getExpiryDate() {
         return expiryDate;
     }
 
     /**
      * Sets the expiry date of the prescription.
-     * @param expiryDate ZonedDateTime representing the new expiry date of the prescription.
+     * @param expiryDate LocalDate representing the new expiry date of the prescription.
      */
-    public void setExpiryDate(ZonedDateTime expiryDate) {
+    public void setExpiryDate(LocalDate expiryDate) {
         this.expiryDate = expiryDate;
     }
 

--- a/src/entities/TimeBlock.java
+++ b/src/entities/TimeBlock.java
@@ -2,71 +2,71 @@
 
 package entities;
 
+import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.ZonedDateTime;
 
 /**
  * Represents a time block.
  */
 public class TimeBlock {
 
-    private ZonedDateTime startTime;
-    private ZonedDateTime endTime;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
     //private Date date; (optional, default = null)
     //private Time time; (required)
     //private Day day; (optional, represents Enum of the days the week, default = null)
 
     /**
      * Creates an instance of TimeBlock.
-     * @param startTime ZonedDateTime representing the time block's start time.
-     * @param endTime ZonedDateTime representing the time block's end time.
+     * @param startTime LocalDateTime representing the time block's start time.
+     * @param endTime LocalDateTime representing the time block's end time.
      */
-    public TimeBlock(ZonedDateTime startTime, ZonedDateTime endTime) {
+    public TimeBlock(LocalDateTime startTime, LocalDateTime endTime) {
         this.startTime = startTime;
         this.endTime = endTime;
     }
 
     /**
-     * @return ZonedDateTime representing the time block's start time.
+     * @return LocalDateTime representing the time block's start time.
      */
-    public ZonedDateTime getStartTime() {
+    public LocalDateTime getStartTime() {
         return startTime;
     }
 
     /**
      * Sets the time block's start time.
-     * @param startTime ZonedDateTime representing the time block's new start time.
+     * @param startTime LocalDateTime representing the time block's new start time.
      */
-    public void setStartTime(ZonedDateTime startTime) {
+    public void setStartTime(LocalDateTime startTime) {
         this.startTime = startTime;
     }
 
     /**
-     * @return ZonedDateTime representing the time block's end time.
+     * @return LocalDateTime representing the time block's end time.
      */
-    public ZonedDateTime getEndTime() {
+    public LocalDateTime getEndTime() {
         return endTime;
     }
 
     /**
      * Sets the time block's end time.
-     * @param endTime ZonedDateTime representing the time block's new end time.
+     * @param endTime LocalDateTime representing the time block's new end time.
      */
-    public void setEndTime(ZonedDateTime endTime) {
+    public void setEndTime(LocalDateTime endTime) {
         this.endTime = endTime;
     }
 
     /**
-     * Converts the ZonedDateTime start time to LocalTime.
-     * @return LocalTime representing the time block's start time in LocalTime.
+     * Converts the LocalDateTime start time to LocalTime.
+     * @return LocalTime representing the time block's start tim.
      */
     public LocalTime startTimeToLocal(){
         return startTime.toLocalTime();
     }
 
     /**
-     * Converts the ZonedDateTime end time to LocalTime.
-     * @return LocalTime representing the time block's end time in LocalTime.
+     * Converts the LocalDateTime end time to LocalTime.
+     * @return LocalTime representing the time block's end time.
      */
     public LocalTime endTimeToLocal(){
         return startTime.toLocalTime();

--- a/src/presenters/entityViews/ClinicView.java
+++ b/src/presenters/entityViews/ClinicView.java
@@ -18,7 +18,6 @@ public class ClinicView extends EntityView<ClinicData> {
         return viewClinicName(item) + "\n"
                 + viewAddress(item) + "\n"
                 + viewEmail(item) + "\n"
-                + viewTimeZone(item) + "\n"
                 + viewPhoneNumber(item) + "\n"
                 + viewClinicHours(item);
     }
@@ -48,15 +47,6 @@ public class ClinicView extends EntityView<ClinicData> {
     public String viewEmail(ClinicData item) {
         String email = getDefaultStringNA(item.getEmail());
         return "This clinic's email is " + email + ".";
-    }
-
-    /**
-     * @param item ClinicData to view.
-     * @return String representing the clinic's time zone as a view.
-     */
-    public String viewTimeZone(ClinicData item) {
-        String timeZone = getDefaultStringNA(item.getTimeZone().toString());
-        return "This clinic's time zone is " + timeZone + ".";
     }
 
     /**

--- a/src/presenters/response/PrescriptionDetails.java
+++ b/src/presenters/response/PrescriptionDetails.java
@@ -1,6 +1,7 @@
 package presenters.response;
 
-import java.time.ZonedDateTime;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 /**
@@ -10,15 +11,15 @@ public final class PrescriptionDetails {
 
     private final String header;
     private final String body;
-    private final ZonedDateTime expiryDate;
+    private final LocalDate expiryDate;
 
     /**
      * Creates an instance of PrescriptionDetails.
      * @param header String representing this prescription's header.
      * @param body String representing this prescription's body.
-     * @param expiryDate ZonedDateTime representing this prescription's expiry date.
+     * @param expiryDate LocalDate representing this prescription's expiry date.
      */
-    public PrescriptionDetails(String header, String body, ZonedDateTime expiryDate) {
+    public PrescriptionDetails(String header, String body, LocalDate expiryDate) {
         this.header = header;
         this.body = body;
         this.expiryDate = expiryDate;
@@ -39,9 +40,9 @@ public final class PrescriptionDetails {
     }
 
     /**
-     * @return ZonedDateTime representing this prescription's expiry date.
+     * @return LocalDate representing this prescription's expiry date.
      */
-    public ZonedDateTime expiryDate() {
+    public LocalDate expiryDate() {
         return expiryDate;
     }
 

--- a/src/presenters/screenViews/DoctorScreenView.java
+++ b/src/presenters/screenViews/DoctorScreenView.java
@@ -6,7 +6,6 @@ import presenters.response.PrescriptionDetails;
 import presenters.response.ReportDetails;
 
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -70,7 +69,7 @@ public class DoctorScreenView extends UserScreenView {
         if (expiryDate == null) {
             return null;
         }
-        return new PrescriptionDetails(header, body, expiryDate.atStartOfDay(ZoneId.of("US/Eastern")));
+        return new PrescriptionDetails(header, body, expiryDate);
     }
 
     /**

--- a/src/presenters/screenViews/SecretaryScreenView.java
+++ b/src/presenters/screenViews/SecretaryScreenView.java
@@ -273,29 +273,27 @@ public class SecretaryScreenView extends UserScreenView {
     }
 
     /**
-     * Prompts user to add a timezone, for START time
-     * @return ZonedDateTime object with the desired input from the user.
+     * Prompts user to add a local start time
+     * @return LocalDateTime object with the desired input from the user.
      */
-    public ZonedDateTime addZoneDateTimeStart() {
+    public LocalDateTime addLocalDateTimeStart() {
         infoMessage("You are about to add the START time: ");
         LocalDate localDate = LocalDate.of(inputInt("year: "), inputInt("month: "),
                 inputInt("day: "));
         LocalTime localTime = LocalTime.MIDNIGHT;
-        ZoneId zoneId = ZoneId.of(input("Zone ID: "));
-        return ZonedDateTime.of(localDate, localTime, zoneId);
+        return LocalDateTime.of(localDate, localTime);
     }
 
     /**
-     * Prompts user to add a timezone for END time
-     * @return ZonedDateTime object with the desired input from the user.
+     * Prompts user to add a local end time
+     * @return LocalDateTime object with the desired input from the user.
      */
-    public ZonedDateTime addZoneDateTimeEnd() {
+    public LocalDateTime addLocalDateTimeEnd() {
         infoMessage("You are about to add the END time: ");
         LocalDate localDate = LocalDate.of(inputInt("year: "), inputInt("month: "),
                 inputInt("day: "));
         LocalTime localTime = LocalTime.MIDNIGHT;
-        ZoneId zoneId = ZoneId.of(input("Zone ID: "));
-        return ZonedDateTime.of(localDate, localTime, zoneId);
+        return LocalDateTime.of(localDate, localTime);
     }
 
     /**

--- a/src/useCases/AppointmentManager.java
+++ b/src/useCases/AppointmentManager.java
@@ -13,8 +13,7 @@ import utilities.TimeUtils;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.stream.Collectors;
 
@@ -151,21 +150,21 @@ public class AppointmentManager {
     public ArrayList<TimeBlockData> getAvailableTimes(DoctorData doctorData, Integer year, Integer month,
                                                     Integer startDay, Integer endDay){
         TimeUtils timeUtils = new TimeUtils();
-        return searchAvailability(doctorData, timeUtils.createZonedDataTime(year, month, startDay, 0, 0),
-                timeUtils.createZonedDataTime(year, month, endDay, 23, 59));
+        return searchAvailability(doctorData, timeUtils.createLocalDateTime(year, month, startDay, 0, 0),
+                timeUtils.createLocalDateTime(year, month, endDay, 23, 59));
     }
 
     /**
      * Gets all available time for a doctor considering their availability, other appointments, and search time
      * parameters.
      * @param doctorData DoctorData - data representing a doctor entity.
-     * @param searchStartTime ZonedDateTime - ZonedDateTime object representing the beginning of the search period.
-     * @param searchEndTime ZonedDateTime - ZonedDateTime object representing the beginning of the end period.
+     * @param searchStartTime LocalDateTime - LocalDateTime object representing the beginning of the search period.
+     * @param searchEndTime LocalDateTime - LocalDateTime object representing the beginning of the end period.
      * @return ArrayList<TimeBlockData> - an ArrayList of TimeBlocks representing all available timeslots to schedule an
      * Appointment.
      */
-    public ArrayList<TimeBlockData> searchAvailability(DoctorData doctorData, ZonedDateTime searchStartTime,
-                                                       ZonedDateTime searchEndTime){
+    public ArrayList<TimeBlockData> searchAvailability(DoctorData doctorData, LocalDateTime searchStartTime,
+                                                       LocalDateTime searchEndTime){
         ArrayList<TimeBlock> totalAvailableTimes = new ArrayList<>();
         for (int numOfDays = searchEndTime.getDayOfYear() - searchStartTime.getDayOfYear(); numOfDays > 0; numOfDays--){
             LocalDate daySearched = searchEndTime.toLocalDate();
@@ -264,10 +263,10 @@ public class AppointmentManager {
     /**
      * Add an absence TimeBlock to a doctor's stored Absence ArrayList.
      * @param doctorData DoctorData - the data representing a specific doctor in the database.
-     * @param startTime ZonedDateTime - a ZonedDateTime representing the beginning of a new absence.
-     * @param endTime ZonedDateTime - a ZonedDateTime representing the ending of a new absence.
+     * @param startTime LocalDateTime - a LocalDateTime representing the beginning of a new absence.
+     * @param endTime LocalDateTime - a LocalDateTime representing the ending of a new absence.
      */
-    public void addAbsence(DoctorData doctorData, ZonedDateTime startTime, ZonedDateTime endTime){
+    public void addAbsence(DoctorData doctorData, LocalDateTime startTime, LocalDateTime endTime){
         TimeBlock proposedTime = new TimeBlock(startTime, endTime);
         doctorDatabase.get(doctorData.getId()).addAbsence(new TimeBlock(startTime, endTime));
         getAllAppointments().stream()
@@ -314,10 +313,8 @@ public class AppointmentManager {
 
     private ArrayList<TimeBlock> getSingleDayAvailability(Integer doctorId, LocalDate selectedDay){
         return getAvailabilityFromDayOfWeek(doctorId, selectedDay.getDayOfWeek()).stream()
-                .map(x -> new TimeBlock(ZonedDateTime.of(selectedDay,
-                        x.getDoctorStartTime(), ZoneId.of("US/Eastern")),
-                        ZonedDateTime.of(selectedDay, x.getDoctorEndTime(),
-                                ZoneId.of("US/Eastern"))))
+                .map(x -> new TimeBlock(LocalDateTime.of(selectedDay, x.getDoctorStartTime()), LocalDateTime
+                        .of(selectedDay, x.getDoctorEndTime())))
                 .collect(Collectors.toCollection(ArrayList::new));
     }
 
@@ -340,7 +337,7 @@ public class AppointmentManager {
     private ArrayList<TimeBlock> parseAvailabilityWithAppointmentData(ArrayList<TimeBlock> availability,
                                                                       Integer doctorId){
         ArrayList<TimeBlock> parsedAvailability = new ArrayList<>();
-        ArrayList<ZonedDateTime> startTime = new ArrayList<>();
+        ArrayList<LocalDateTime> startTime = new ArrayList<>();
         for (TimeBlock availabilityTimeBlock: availability) {
             startTime.add(availabilityTimeBlock.getStartTime());
             ArrayList<TimeBlock> allConflicts = getAppointmentsTimeBlock();
@@ -357,7 +354,7 @@ public class AppointmentManager {
         return parsedAvailability;
     }
 
-    private boolean calculateNoConflictTime(TimeBlock timeBlock, ArrayList<ZonedDateTime> startTime,
+    private boolean calculateNoConflictTime(TimeBlock timeBlock, ArrayList<LocalDateTime> startTime,
                                             ArrayList<TimeBlock> collectedTimeBlocks){
         if (startTime.get(0).equals(timeBlock.getEndTime())){
             startTime.remove(0);

--- a/src/useCases/PrescriptionManager.java
+++ b/src/useCases/PrescriptionManager.java
@@ -8,8 +8,7 @@ import database.Database;
 import entities.Prescription;
 import utilities.DatabaseQueryUtility;
 
-import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.stream.Stream;
 
@@ -61,11 +60,11 @@ public class PrescriptionManager {
      * @param body String - body of the prescription, all notes relating to the prescription.
      * @param patientData PatientData - data pertaining to a specific patient in the database.
      * @param doctorData DoctorData - data pertaining to a specific doctor in the database.
-     * @param expiryDate ZonedDateTime - date the prescription expires.
+     * @param expiryDate LocalDate - date the prescription expires.
      * @return PrescriptionData - prescription data that stores the information passed in.
      */
     public PrescriptionData createPrescription(String header, String body, PatientData patientData, DoctorData doctorData,
-                                               ZonedDateTime expiryDate){
+                                               LocalDate expiryDate){
         Prescription prescription = new Prescription(header, body, patientData.getId(), doctorData.getId(), expiryDate);
         prescriptionsDatabase.add(prescription);
         return new PrescriptionData(prescription);
@@ -80,7 +79,7 @@ public class PrescriptionManager {
     }
 
     private boolean isExpiredPrescription(Prescription prescription){
-        return prescription.getExpiryDate().toLocalDateTime().isBefore(LocalDateTime.now());
+        return prescription.getExpiryDate().isBefore(LocalDate.now());
     }
 
     private Stream<Prescription> getAll(PatientData patient){

--- a/src/utilities/TimeUtils.java
+++ b/src/utilities/TimeUtils.java
@@ -4,17 +4,15 @@ package utilities;
 
 import entities.TimeBlock;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.*;
+
 /**
  * Utility class of methods relating to usage of time, used anything related to appointments, absence, availability, and
  * time blocks.
  */
 public class TimeUtils {
     /**
-     * A method that creates a time block without requiring an input of ZonedDateTimes.
+     * A method that creates a time block without requiring an input of LocalDateTime.
      * @param year              an integer that represents the year for a time block to exist.
      * @param month             an integer that represents the month of the given year.
      * @param day               an integer that represents a day of a given month.
@@ -24,15 +22,9 @@ public class TimeUtils {
      * @return a TimeBlock grouping together all the inputted data.
      */
     public TimeBlock createTimeBlock(Integer year, Integer month, Integer day, Integer hour, Integer minute, Integer lenOfAppointment){
-        ZonedDateTime starTime = createZonedDataTime(year, month, day, hour, minute);
-        TimeBlock proposedTime = new TimeBlock(createZonedDataTime(year, month, day, hour, minute),
-                starTime.plusMinutes(lenOfAppointment));
-        if (proposedTime.getStartTime().isBefore(getCurrentZonedDateTime())){
-            proposedTime.getStartTime().plusYears(1);
-            proposedTime.getEndTime().plusYears(1);
-            return proposedTime;
-        }
-        return proposedTime;
+        LocalDateTime startTime = createLocalDateTime(year, month, day, hour, minute);
+        return new TimeBlock(createLocalDateTime(year, month, day, hour, minute),
+                startTime.plusMinutes(lenOfAppointment));
     }
 
     /**
@@ -58,26 +50,26 @@ public class TimeUtils {
     }
 
     /**
-     *Creates a zoned date time which holds both a time and a date.
+     *Creates a local date time which holds both a time and a date.
      * @param year          an integer that represents the year for a time block to exist.
      * @param month         an integer that represents the month of the given year.
      * @param dayOfMonth    an integer that represents a day of a given month.
      * @param hour          an integer that represents an hour of a given day.
      * @param minute        an integer that represents a minute of a given hour.
-     * @return a ZonedDateTime from inputted data.
+     * @return a LocalDateTime from inputted data.
      */
-    public ZonedDateTime createZonedDataTime(Integer year, Integer month, Integer dayOfMonth, Integer hour,
+    public LocalDateTime createLocalDateTime(Integer year, Integer month, Integer dayOfMonth, Integer hour,
                                              Integer minute){
-        return ZonedDateTime.of(year, month, dayOfMonth, hour,
-                minute, 0, 0, ZoneId.of("US/Eastern"));
+        return LocalDateTime.of(year, month, dayOfMonth, hour,
+                minute, 0, 0);
     }
 
     /**
-     * gets the current zoned date time of the system, in US/Eastern timezone.
-     * @return a ZonedDateTime from the system.
+     * gets the current local date time of the system.
+     * @return a LocalDateTime from the system.
      */
-    public ZonedDateTime getCurrentZonedDateTime(){
-        return ZonedDateTime.now(ZoneId.of("US/Eastern"));
+    public LocalDateTime getCurrentLocalDateTime(){
+        return LocalDateTime.now();
     }
 
     /**

--- a/test/AppointmentManagerTests.java
+++ b/test/AppointmentManagerTests.java
@@ -15,7 +15,6 @@ import utilities.DeleteUtils;
 import java.io.File;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,7 +29,7 @@ public class AppointmentManagerTests {
     public void testBookAppointment() {
         Database originalDatabase = new Database(databaseFolder.toString());
 
-        originalDatabase.setClinic(new Clinic("", "", "","", ZoneId.of("US/Eastern"),
+        originalDatabase.setClinic(new Clinic("", "", "","",
                 new ArrayList<>(List.of(new Availability(DayOfWeek.of(1), LocalTime.of(8, 30),
                         LocalTime.of(17, 0))))));
 
@@ -72,7 +71,7 @@ public class AppointmentManagerTests {
 //    public void testBookInvalidAppointments() {
 //        Database originalDatabase = new Database(databaseFolder.toString());
 //
-//        originalDatabase.setClinic(new Clinic("", "", "","", ZoneId.of("US/Eastern"),
+//        originalDatabase.setClinic(new Clinic("", "", "","",
 //                new ArrayList<>(List.of(new Availability(DayOfWeek.of(1), LocalTime.of(8, 30),
 //                        LocalTime.of(17, 0))))));
 //
@@ -160,7 +159,7 @@ public class AppointmentManagerTests {
     public void testRemoveAppointment() {
         Database originalDatabase = new Database(databaseFolder.toString());
 
-        originalDatabase.setClinic(new Clinic("", "", "","", ZoneId.of("US/Eastern"),
+        originalDatabase.setClinic(new Clinic("", "", "","",
                 new ArrayList<>(List.of(new Availability(DayOfWeek.of(1), LocalTime.of(8, 30),
                         LocalTime.of(17, 0))))));
 

--- a/test/ClinicManagerTests.java
+++ b/test/ClinicManagerTests.java
@@ -12,7 +12,6 @@ import utilities.DeleteUtils;
 import java.io.File;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,7 +26,6 @@ public class ClinicManagerTests {
         Database originalDatabase = new Database(databaseFolder.toString());
 
         Clinic clinic = new Clinic("ABC", "4169782011", "abc@gmail.com", "address",
-                ZoneId.of("US/Eastern"),
                 new ArrayList<>(List.of(new Availability(DayOfWeek.of(1), LocalTime.of(8, 30),
                 LocalTime.of(17, 0)))));
         originalDatabase.setClinic(clinic);
@@ -48,7 +46,6 @@ public class ClinicManagerTests {
         Database originalDatabase = new Database(databaseFolder.toString());
 
         Clinic clinic = new Clinic("ABC", "4169782011", "abc@gmail.com", "address",
-                ZoneId.of("US/Eastern"),
                 new ArrayList<>(List.of(new Availability(DayOfWeek.of(1), LocalTime.of(8, 30),
                         LocalTime.of(17, 0)))));
         originalDatabase.setClinic(clinic);
@@ -69,7 +66,6 @@ public class ClinicManagerTests {
         Database originalDatabase = new Database(databaseFolder.toString());
 
         Clinic clinic = new Clinic("ABC", "4169782011", "abc@gmail.com", "address",
-                ZoneId.of("US/Eastern"),
                 new ArrayList<>(List.of(new Availability(DayOfWeek.of(1), LocalTime.of(8, 30),
                         LocalTime.of(17, 0)))));
         originalDatabase.setClinic(clinic);
@@ -90,7 +86,6 @@ public class ClinicManagerTests {
         Database originalDatabase = new Database(databaseFolder.toString());
 
         Clinic clinic = new Clinic("ABC", "4169782011", "abc@gmail.com", "address",
-                ZoneId.of("US/Eastern"),
                 new ArrayList<>(List.of(new Availability(DayOfWeek.of(1), LocalTime.of(8, 30),
                         LocalTime.of(17, 0)))));
         originalDatabase.setClinic(clinic);
@@ -111,7 +106,6 @@ public class ClinicManagerTests {
         Database originalDatabase = new Database(databaseFolder.toString());
 
         Clinic clinic = new Clinic("ABC", "4169782011", "abc@gmail.com", "address",
-                ZoneId.of("US/Eastern"),
                 new ArrayList<>(List.of(new Availability(DayOfWeek.of(1), LocalTime.of(8, 30),
                         LocalTime.of(17, 0)))));
 
@@ -133,7 +127,6 @@ public class ClinicManagerTests {
         Database originalDatabase = new Database(databaseFolder.toString());
 
         Clinic clinic = new Clinic("ABC", "4169782011", "abc@gmail.com", "address",
-                ZoneId.of("US/Eastern"),
                 new ArrayList<>(List.of(new Availability(DayOfWeek.of(1), LocalTime.of(8, 30),
                         LocalTime.of(17, 0)))));
 

--- a/test/DatabaseTests.java
+++ b/test/DatabaseTests.java
@@ -130,15 +130,11 @@ public class DatabaseTests {
         Database originalDatabase = new Database(databaseFolder.toString());
         DataMapperGateway<Prescription> originalPrescriptionDatabase = originalDatabase.getPrescriptionDatabase();
 
-        LocalDateTime localDateNoted = LocalDateTime.of(2022,7,1,4,3);
-        LocalDateTime localExpiryDate = LocalDateTime.of(2024, 7, 1, 0, 0);
-        ZoneId torontoID = ZoneId.of("Canada/Eastern");
-        ZonedDateTime zonedDateNoted = ZonedDateTime.of(localDateNoted, torontoID);
-        ZonedDateTime zonedExpiryDate = ZonedDateTime.of(localExpiryDate, torontoID);
+        LocalDate localExpiryDate = LocalDate.of(2024, 7, 1);
 
         Prescription originalPrescription = new
                 Prescription("medicine", "healthy", 123,
-                456, zonedExpiryDate);
+                456, localExpiryDate);
 
         Integer prescriptionID = originalPrescriptionDatabase.add(originalPrescription);
         originalPrescriptionDatabase.save();
@@ -170,10 +166,6 @@ public class DatabaseTests {
     public void testSaveLoadReportDatabase() {
         Database originalDatabase = new Database(databaseFolder.toString());
         DataMapperGateway<Report> originalReportDatabase = originalDatabase.getReportDatabase();
-
-        LocalDateTime localDateNoted = LocalDateTime.of(2022,7,1,4,3);
-        ZoneId torontoID = ZoneId.of("Canada/Eastern");
-        ZonedDateTime zonedDateNoted = ZonedDateTime.of(localDateNoted, torontoID);
 
         Report originalReport = new
                 Report("medicine", "healthy", 123,
@@ -209,10 +201,7 @@ public class DatabaseTests {
 
         LocalDateTime localStartTime = LocalDateTime.of(2022,7,1,4,3);
         LocalDateTime localEndTime = LocalDateTime.of(2022,7,1,6,3);
-        ZoneId torontoID = ZoneId.of("Canada/Eastern");
-        ZonedDateTime zonedStartTime = ZonedDateTime.of(localStartTime, torontoID);
-        ZonedDateTime zonedEndTime = ZonedDateTime.of(localEndTime, torontoID);
-        TimeBlock timeBlock = new TimeBlock(zonedStartTime, zonedEndTime);
+        TimeBlock timeBlock = new TimeBlock(localStartTime, localEndTime);
 
         Appointment originalAppointment = new Appointment(timeBlock,  123, 456);
 
@@ -307,11 +296,10 @@ public class DatabaseTests {
     public void testSetGetClinic() {
         Database originalDatabase = new Database(databaseFolder.toString());
 
-        ZoneId torontoID = ZoneId.of("Canada/Eastern");
         ArrayList<Availability> clinicHours = new ArrayList<>();
         clinicHours.add(new Availability(DayOfWeek.of(1), LocalTime.of(8, 0), LocalTime.of(20, 0)));
         Clinic originalClinic = new Clinic("jeff clinic",  "12345678", "abc@gmail.com",
-                "21 jump street", torontoID, clinicHours);
+                "21 jump street", clinicHours);
 
         originalDatabase.setClinic(originalClinic);
 
@@ -328,8 +316,6 @@ public class DatabaseTests {
                 originalClinic.getPhoneNumber(), loadedClinic.getPhoneNumber());
         assertEquals("Original clinic and loaded clinic should share the same address",
                 originalClinic.getAddress(), loadedClinic.getAddress());
-        assertEquals("Original clinic and loaded clinic should share the same time zone",
-                originalClinic.getTimeZone().toString(), loadedClinic.getTimeZone().toString());
         assertEquals("Original clinic and loaded clinic should start at the same time",
                 originalClinic.getClinicHours().get(0).getDoctorStartTime().compareTo(loadedClinic.getClinicHours().get(0).
                         getDoctorStartTime()), 0); // the compareTo function returns 0 when both dates are equal

--- a/test/PrescriptionManagerTests.java
+++ b/test/PrescriptionManagerTests.java
@@ -17,9 +17,7 @@ import utilities.DeleteUtils;
 import static org.junit.Assert.*;
 
 import java.io.File;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.LocalDate;
 import java.util.ArrayList;
 
 import static org.junit.Assert.assertEquals;
@@ -34,20 +32,16 @@ public class PrescriptionManagerTests {
         Database originalDatabase = new Database(databaseFolder.toString());
         DataMapperGateway<Prescription> prescriptionDatabase = originalDatabase.getPrescriptionDatabase();
 
-        LocalDateTime localDateNoted = LocalDateTime.of(2022,7,1,4,3);
-        LocalDateTime localExpiryDate = LocalDateTime.of(2050, 7, 1, 0, 0);
-        ZoneId torontoID = ZoneId.of("Canada/Eastern");
-        ZonedDateTime zonedDateNoted = ZonedDateTime.of(localDateNoted, torontoID);
-        ZonedDateTime zonedExpiryDate = ZonedDateTime.of(localExpiryDate, torontoID);
+        LocalDate localExpiryDate = LocalDate.of(2050, 7, 1);
 
         PatientData patient = new PatientManager(originalDatabase).createPatient("test 4", "test4");
         DoctorData doctor = new DoctorManager(originalDatabase).createDoctor("test 3", "test4");
 
         Prescription originalPrescription1 = new
-                Prescription("medicine", "healthy", patient.getId(), doctor.getId(), zonedExpiryDate);
+                Prescription("medicine", "healthy", patient.getId(), doctor.getId(), localExpiryDate);
         Prescription originalPrescription2 = new
                 Prescription("bad", "very unhealthy", patient.getId(),
-                doctor.getId(), zonedExpiryDate);
+                doctor.getId(), localExpiryDate);
 
         Integer prescriptionID1 = prescriptionDatabase.add(originalPrescription1);
         Integer prescriptionID2 = prescriptionDatabase.add(originalPrescription2);
@@ -88,18 +82,14 @@ public class PrescriptionManagerTests {
         PatientData patient = new PatientManager(originalDatabase).createPatient("test 4", "test4");
         DoctorData doctor = new DoctorManager(originalDatabase).createDoctor("test 3", "test4");
 
-        LocalDateTime localDateNoted = LocalDateTime.of(2020,7,1,4,3);
-        LocalDateTime localExpiryDate = LocalDateTime.of(2021, 7, 1, 0, 0);
-        ZoneId torontoID = ZoneId.of("Canada/Eastern");
-        ZonedDateTime zonedDateNoted = ZonedDateTime.of(localDateNoted, torontoID);
-        ZonedDateTime zonedExpiryDate = ZonedDateTime.of(localExpiryDate, torontoID);
+        LocalDate localExpiryDate = LocalDate.of(2021, 7, 1);
 
         Prescription originalPrescription1 = new
                 Prescription("medicine", "healthy", patient.getId(),
-                doctor.getId(), zonedExpiryDate);
+                doctor.getId(), localExpiryDate);
         Prescription originalPrescription2 = new
                 Prescription("bad", "very unhealthy", doctor.getId(),
-                doctor.getId(), zonedExpiryDate);
+                doctor.getId(), localExpiryDate);
 
         Integer prescriptionID1 = prescriptionDatabase.add(originalPrescription1);
         Integer prescriptionID2 = prescriptionDatabase.add(originalPrescription2);
@@ -120,20 +110,15 @@ public class PrescriptionManagerTests {
         PatientData patient = new PatientManager(originalDatabase).createPatient("test 4", "test4");
         DoctorData doctor = new DoctorManager(originalDatabase).createDoctor("test 3", "test4");
 
-        LocalDateTime localDateNoted = LocalDateTime.of(2020,7,1,4,3);
-        LocalDateTime inactiveLocalExpiryDate = LocalDateTime.of(2021, 7, 1, 0, 0);
-        LocalDateTime activeLocalExpiryDate = LocalDateTime.of(2050, 7, 1, 0, 0);
-        ZoneId torontoID = ZoneId.of("Canada/Eastern");
-        ZonedDateTime zonedDateNoted = ZonedDateTime.of(localDateNoted, torontoID);
-        ZonedDateTime inactiveZonedExpiryDate = ZonedDateTime.of(inactiveLocalExpiryDate, torontoID);
-        ZonedDateTime activeZonedExpiryDate = ZonedDateTime.of(activeLocalExpiryDate, torontoID);
+        LocalDate inactiveLocalExpiryDate = LocalDate.of(2021, 7, 1);
+        LocalDate activeLocalExpiryDate = LocalDate.of(2050, 7, 1);
 
         Prescription originalPrescription1 = new
                 Prescription("medicine", "healthy", patient.getId(),
-                doctor.getId(), inactiveZonedExpiryDate);
+                doctor.getId(), inactiveLocalExpiryDate);
         Prescription originalPrescription2 = new
                 Prescription("bad", "very unhealthy", patient.getId(),
-                doctor.getId(), activeZonedExpiryDate);
+                doctor.getId(), activeLocalExpiryDate);
 
         Integer prescriptionID1 = prescriptionDatabase.add(originalPrescription1);
         Integer prescriptionID2 = prescriptionDatabase.add(originalPrescription2);
@@ -155,18 +140,14 @@ public class PrescriptionManagerTests {
         PatientData patient = new PatientManager(originalDatabase).createPatient("test 4", "test4");
         DoctorData doctor = new DoctorManager(originalDatabase).createDoctor("test 3", "test4");
 
-        LocalDateTime localDateNoted = LocalDateTime.of(2022,7,1,4,3);
-        LocalDateTime localExpiryDate = LocalDateTime.of(2050, 7, 1, 0, 0);
-        ZoneId torontoID = ZoneId.of("Canada/Eastern");
-        ZonedDateTime zonedDateNoted = ZonedDateTime.of(localDateNoted, torontoID);
-        ZonedDateTime zonedExpiryDate = ZonedDateTime.of(localExpiryDate, torontoID);
+        LocalDate localExpiryDate = LocalDate.of(2050, 7, 1);
         String header = "medicine";
         String body = "healthy";
 
         PrescriptionManager prescriptionManager = new PrescriptionManager(originalDatabase);
 
         PrescriptionData prescriptionData = prescriptionManager.createPrescription(header, body, patient,
-                doctor, zonedExpiryDate);
+                doctor, localExpiryDate);
 
         /* testing if the created prescription data is valid by testing if its fields match with the parameters
         * of the createPrescription method */
@@ -179,7 +160,7 @@ public class PrescriptionManagerTests {
         assertEquals("The created prescription data should have the same patient ID noted as the " +
                 "parameters of createPrescription method", prescriptionData.getDoctorId(), doctor.getId());
         assertEquals("Original prescription and loaded prescription have the same expiry date",
-                prescriptionData.getExpiryDate().compareTo(zonedExpiryDate), 0);
+                prescriptionData.getExpiryDate().compareTo(localExpiryDate), 0);
 
         Prescription loadedPrescription = prescriptionDatabase.get(prescriptionData.getPrescriptionId());
 
@@ -194,7 +175,7 @@ public class PrescriptionManagerTests {
         assertEquals("The loaded prescription object should have the same patient ID noted as the " +
                 "parameters of createPrescription method", prescriptionData.getDoctorId(), doctor.getId());
         assertEquals("The loaded prescription object should have the same expiry as the parameters of " +
-                        "createPrescription method", prescriptionData.getExpiryDate().compareTo(zonedExpiryDate),
+                        "createPrescription method", prescriptionData.getExpiryDate().compareTo(localExpiryDate),
                 0);
     }
 
@@ -206,20 +187,15 @@ public class PrescriptionManagerTests {
         PatientData patient = new PatientManager(originalDatabase).createPatient("test 4", "test4");
         DoctorData doctor = new DoctorManager(originalDatabase).createDoctor("test 3", "test4");
 
-        LocalDateTime localDateNoted = LocalDateTime.of(2020,7,1,4,3);
-        LocalDateTime inactiveLocalExpiryDate = LocalDateTime.of(2021, 7, 1, 0, 0);
-        LocalDateTime activeLocalExpiryDate = LocalDateTime.of(2050, 7, 1, 0, 0);
-        ZoneId torontoID = ZoneId.of("Canada/Eastern");
-        ZonedDateTime zonedDateNoted = ZonedDateTime.of(localDateNoted, torontoID);
-        ZonedDateTime inactiveZonedExpiryDate = ZonedDateTime.of(inactiveLocalExpiryDate, torontoID);
-        ZonedDateTime activeZonedExpiryDate = ZonedDateTime.of(activeLocalExpiryDate, torontoID);
+        LocalDate inactiveLocalExpiryDate = LocalDate.of(2021, 7, 1);
+        LocalDate activeLocalExpiryDate = LocalDate.of(2050, 7, 1);
 
         Prescription originalPrescription1 = new
                 Prescription("medicine", "healthy", patient.getId(),
-                doctor.getId(), inactiveZonedExpiryDate);
+                doctor.getId(), inactiveLocalExpiryDate);
         Prescription originalPrescription2 = new
                 Prescription("bad", "very unhealthy", patient.getId(),
-                doctor.getId(), activeZonedExpiryDate);
+                doctor.getId(), activeLocalExpiryDate);
 
         Integer prescriptionID1 = prescriptionDatabase.add(originalPrescription1);
         Integer prescriptionID2 = prescriptionDatabase.add(originalPrescription2);
@@ -257,20 +233,15 @@ public class PrescriptionManagerTests {
         PatientData patient2 = new PatientManager(originalDatabase).createPatient("test 5", "test4");
         DoctorData doctor = new DoctorManager(originalDatabase).createDoctor("test 3", "test4");
 
-        LocalDateTime localDateNoted = LocalDateTime.of(2020,7,1,4,3);
-        LocalDateTime inactiveLocalExpiryDate = LocalDateTime.of(2021, 7, 1, 0, 0);
-        LocalDateTime activeLocalExpiryDate = LocalDateTime.of(2050, 7, 1, 0, 0);
-        ZoneId torontoID = ZoneId.of("Canada/Eastern");
-        ZonedDateTime zonedDateNoted = ZonedDateTime.of(localDateNoted, torontoID);
-        ZonedDateTime inactiveZonedExpiryDate = ZonedDateTime.of(inactiveLocalExpiryDate, torontoID);
-        ZonedDateTime activeZonedExpiryDate = ZonedDateTime.of(activeLocalExpiryDate, torontoID);
+        LocalDate inactiveLocalExpiryDate = LocalDate.of(2021, 7, 1);
+        LocalDate activeLocalExpiryDate = LocalDate.of(2050, 7, 1);
 
         Prescription originalPrescription1 = new
                 Prescription("medicine", "healthy", patient.getId(),
-                doctor.getId(), inactiveZonedExpiryDate);
+                doctor.getId(), inactiveLocalExpiryDate);
         Prescription originalPrescription2 = new
                 Prescription("bad", "very unhealthy", patient.getId(),
-                doctor.getId(), activeZonedExpiryDate);
+                doctor.getId(), activeLocalExpiryDate);
 
         prescriptionDatabase.add(originalPrescription1);
         prescriptionDatabase.add(originalPrescription2);


### PR DESCRIPTION
Refactored the codebase to exclusively use local date and local date time objects instead of alternating between local date time and zoned date time. Additionally, I refactored the expiry dates of prescriptions to be local date objects rather than local date time objects.