### PR TITLE
feat: add regex username and password feature

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -39,7 +39,7 @@ public class Main {
         // Bootstrap database with default clinic and admin
         bootstrapClinic(database);
         AdminManager adminManager = new AdminManager(database);
-        adminManager.createAdmin("root", "root");
+        adminManager.createAdmin("aadmin", "aadmin");
         database.save();
 
         Context c = new Context(database);

--- a/src/Main.java
+++ b/src/Main.java
@@ -39,7 +39,7 @@ public class Main {
         // Bootstrap database with default clinic and admin
         bootstrapClinic(database);
         AdminManager adminManager = new AdminManager(database);
-        adminManager.createAdmin("aadmin", "aadmin");
+        adminManager.createAdmin("admin1", "12345678");
         database.save();
 
         Context c = new Context(database);

--- a/src/controllers/AdminController.java
+++ b/src/controllers/AdminController.java
@@ -71,7 +71,7 @@ public class AdminController extends UserController<Admin> {
         return (x) -> {
             UserCredentials c = adminScreenView.registerSecretaryPrompt();
             SecretaryData secretary = secretaryManager.createSecretary(c.username(), c.password());
-            displaySuccessOnCreateAccount(secretary);
+            displaySuccessOnCreateAccount(secretary, "secretary");
         };
     }
 
@@ -80,16 +80,15 @@ public class AdminController extends UserController<Admin> {
         return (x) -> {
             UserCredentials userCred = adminScreenView.registerDoctorPrompt();
             DoctorData doctor = doctorManager.createDoctor(userCred.username(), userCred.password());
-            displaySuccessOnCreateAccount(doctor);
+            displaySuccessOnCreateAccount(doctor, "doctor");
         };
     }
 
     private Command CreateAdmin() {
         return (x) -> {
-
             UserCredentials userCred = adminScreenView.registerAdminPrompt();
             AdminData admin = adminManager.createAdmin(userCred.username(), userCred.password());
-            displaySuccessOnCreateAccount(admin);
+            displaySuccessOnCreateAccount(admin, "admin");
         };
     }
 
@@ -98,15 +97,15 @@ public class AdminController extends UserController<Admin> {
         return (x) -> {
             UserCredentials userCred = adminScreenView.registerPatientPrompt();
             PatientData patient = patientManager.createPatient(userCred.username(), userCred.password());
-            displaySuccessOnCreateAccount(patient);
+            displaySuccessOnCreateAccount(patient, "patient");
         };
     }
 
-    private void displaySuccessOnCreateAccount(UserData<?> user) {
+    private void displaySuccessOnCreateAccount(UserData<?> user, String userType) {
         if (user == null) {
-            adminScreenView.showFailedToRegisterUserError();
+            adminScreenView.showFailedToRegisterUserError(userType);
         } else {
-            adminScreenView.showRegisterUserSuccess();
+            adminScreenView.showRegisterUserSuccess(userType);
         }
     }
 

--- a/src/controllers/AdminController.java
+++ b/src/controllers/AdminController.java
@@ -69,41 +69,57 @@ public class AdminController extends UserController<Admin> {
     private Command CreateSecretary() {
         SecretaryManager secretaryManager = new SecretaryManager(getDatabase());
         return (x) -> {
-            UserCredentials c = adminScreenView.registerSecretaryPrompt();
-            SecretaryData secretary = secretaryManager.createSecretary(c.username(), c.password());
-            displaySuccessOnCreateAccount(secretary, "secretary");
+            try {
+                UserCredentials c = adminScreenView.registerSecretaryPrompt();
+                SecretaryData secretary = secretaryManager.createSecretary(c.username(), c.password());
+                displaySuccessOnCreateAccount(secretary, "secretary");
+            } catch (IllegalArgumentException iae) {
+                adminScreenView.showIncorrectFormatError("secretary");
+            }
         };
     }
 
     private Command CreateDoctor() {
         DoctorManager doctorManager = new DoctorManager(getDatabase());
         return (x) -> {
-            UserCredentials userCred = adminScreenView.registerDoctorPrompt();
-            DoctorData doctor = doctorManager.createDoctor(userCred.username(), userCred.password());
-            displaySuccessOnCreateAccount(doctor, "doctor");
+            try {
+                UserCredentials userCred = adminScreenView.registerDoctorPrompt();
+                DoctorData doctor = doctorManager.createDoctor(userCred.username(), userCred.password());
+                displaySuccessOnCreateAccount(doctor, "doctor");
+            } catch (IllegalArgumentException iae) {
+                adminScreenView.showIncorrectFormatError("doctor");
+            }
         };
     }
 
     private Command CreateAdmin() {
         return (x) -> {
-            UserCredentials userCred = adminScreenView.registerAdminPrompt();
-            AdminData admin = adminManager.createAdmin(userCred.username(), userCred.password());
-            displaySuccessOnCreateAccount(admin, "admin");
+            try {
+                UserCredentials userCred = adminScreenView.registerAdminPrompt();
+                AdminData admin = adminManager.createAdmin(userCred.username(), userCred.password());
+                displaySuccessOnCreateAccount(admin, "admin");
+            } catch (IllegalArgumentException iae) {
+                adminScreenView.showIncorrectFormatError("admin");
+            }
         };
     }
 
     private Command CreatePatient() {
         PatientManager patientManager = new PatientManager(getDatabase());
         return (x) -> {
-            UserCredentials userCred = adminScreenView.registerPatientPrompt();
-            PatientData patient = patientManager.createPatient(userCred.username(), userCred.password());
-            displaySuccessOnCreateAccount(patient, "patient");
+            try {
+                UserCredentials userCred = adminScreenView.registerPatientPrompt();
+                PatientData patient = patientManager.createPatient(userCred.username(), userCred.password());
+                displaySuccessOnCreateAccount(patient, "patient");
+            } catch (IllegalArgumentException iae) {
+                adminScreenView.showIncorrectFormatError("patient");
+            }
         };
     }
 
     private void displaySuccessOnCreateAccount(UserData<?> user, String userType) {
         if (user == null) {
-            adminScreenView.showFailedToRegisterUserError(userType);
+            adminScreenView.showUsernameInUseError(userType);
         } else {
             adminScreenView.showRegisterUserSuccess(userType);
         }

--- a/src/controllers/AdminUserManagementController.java
+++ b/src/controllers/AdminUserManagementController.java
@@ -72,37 +72,61 @@ public class AdminUserManagementController extends TerminalController {
 
     private Command CreateAdmin(){
         return (x) -> {
-            UserCredentials userCred = adminScreenView.registerAdminPrompt();
-            AdminData admin = adminManager.createAdmin(userCred.username(), userCred.password());
-            displayCreateAccountSuccess(admin);
+            try {
+                UserCredentials userCred = adminScreenView.registerAdminPrompt();
+                AdminData admin = adminManager.createAdmin(userCred.username(), userCred.password());
+                displaySuccessOnCreateAccount(admin, "admin");
+            } catch (IllegalArgumentException iae) {
+                adminScreenView.showIncorrectFormatError("admin");
+            }
         };
     }
 
     private Command CreateDoctor(){
         DoctorManager doctorManager = new DoctorManager(getDatabase());
         return (x) -> {
-            UserCredentials userCred = adminScreenView.registerDoctorPrompt();
-            DoctorData doctor = doctorManager.createDoctor(userCred.username(), userCred.password());
-            displayCreateAccountSuccess(doctor);
+            try {
+                UserCredentials userCred = adminScreenView.registerDoctorPrompt();
+                DoctorData doctor = doctorManager.createDoctor(userCred.username(), userCred.password());
+                displaySuccessOnCreateAccount(doctor, "doctor");
+            } catch (IllegalArgumentException iae) {
+                adminScreenView.showIncorrectFormatError("doctor");
+            }
         };
     }
 
     private Command CreatePatient(){
         PatientManager patientManager = new PatientManager(getDatabase());
         return (x) -> {
-            UserCredentials userCred = adminScreenView.registerPatientPrompt();
-            PatientData patient = patientManager.createPatient(userCred.username(), userCred.password());
-            displayCreateAccountSuccess(patient);
+            try {
+                UserCredentials userCred = adminScreenView.registerPatientPrompt();
+                PatientData patient = patientManager.createPatient(userCred.username(), userCred.password());
+                displaySuccessOnCreateAccount(patient, "patient");
+            } catch (IllegalArgumentException iae) {
+                adminScreenView.showIncorrectFormatError("patient");
+            }
         };
     }
 
     private Command CreateSecretary(){
         SecretaryManager secretaryManager = new SecretaryManager(getDatabase());
         return (x) -> {
-            UserCredentials userCred = adminScreenView.registerSecretaryPrompt();
-            SecretaryData secretary = secretaryManager.createSecretary(userCred.username(), userCred.password());
-            displayCreateAccountSuccess(secretary);
+            try {
+                UserCredentials c = adminScreenView.registerSecretaryPrompt();
+                SecretaryData secretary = secretaryManager.createSecretary(c.username(), c.password());
+                displaySuccessOnCreateAccount(secretary, "secretary");
+            } catch (IllegalArgumentException iae) {
+                adminScreenView.showIncorrectFormatError("secretary");
+            }
         };
+    }
+
+    private void displaySuccessOnCreateAccount(UserData<?> user, String userType) {
+        if (user == null) {
+            adminScreenView.showUsernameInUseError(userType);
+        } else {
+            adminScreenView.showRegisterUserSuccess(userType);
+        }
     }
 
     private Command DeleteUser() {
@@ -117,14 +141,6 @@ public class AdminUserManagementController extends TerminalController {
                 adminScreenView.showFailedToDeleteUserError();
             }
         };
-    }
-
-    private void displayCreateAccountSuccess(UserData<?> user) {
-        if (user == null) {
-            adminScreenView.showFailedToRegisterUserError();
-        } else {
-            adminScreenView.showRegisterUserSuccess();
-        }
     }
 
     private <T extends User> boolean changePassword(UserManager<T> manager, String name) {

--- a/src/controllers/SecretaryController.java
+++ b/src/controllers/SecretaryController.java
@@ -86,26 +86,18 @@ public class SecretaryController extends UserController<Secretary> {
     private Command createPatientAccount() {
         PatientManager patientManager = new PatientManager(getDatabase());
         return (x) -> {
-            UserCredentials userCred = secretaryScreenView.registerPatientPrompt();
-            PatientData patient = patientManager.createPatient(userCred.username(), userCred.password());
-            if (patient == null) {
-                secretaryScreenView.showFailedToRegisterPatientError();
-            } else {
-                secretaryScreenView.showRegisterPatientSuccess();
+            try {
+                UserCredentials userCred = secretaryScreenView.registerPatientPrompt();
+                PatientData patient = patientManager.createPatient(userCred.username(), userCred.password());
+                if (patient == null) {
+                    secretaryScreenView.showPatientUsernameInUseError();
+                } else {
+                    secretaryScreenView.showRegisterPatientSuccess();
+                }
+            } catch (IllegalArgumentException iae) {
+                secretaryScreenView.showIncorrectPatientFormatError();
             }
         };
-//        return (x) -> {
-//            UserCredentials userCredentials = secretaryScreenView.registerPatientAccount();
-//            if (!patientManager.doesUserExist(userCredentials.username()) &&
-//                    !doctorManager.doesUserExist(userCredentials.username()) &&
-//                    !adminManager.doesUserExist(userCredentials.username()) &&
-//                    !secretaryManager.doesUserExist(userCredentials.username())) {
-//                patientManager.createPatient(userCredentials.username(), userCredentials.password());
-//                secretaryScreenView.showRegisterPatientSuccess();
-//            } else {
-//                secretaryScreenView.showRegisterPatientError();
-//            }
-//        };
     }
 
     private Command deletePatient() {

--- a/src/controllers/SecretaryController.java
+++ b/src/controllers/SecretaryController.java
@@ -84,19 +84,28 @@ public class SecretaryController extends UserController<Secretary> {
     }
 
     private Command createPatientAccount() {
+        PatientManager patientManager = new PatientManager(getDatabase());
         return (x) -> {
-            UserCredentials userCredentials = secretaryScreenView.registerPatientAccount();
-            if (!patientManager.doesUserExist(userCredentials.username()) &&
-                    !doctorManager.doesUserExist(userCredentials.username()) &&
-                    !adminManager.doesUserExist(userCredentials.username()) &&
-                    !secretaryManager.doesUserExist(userCredentials.username())) {
-                patientManager.createPatient(userCredentials.username(), userCredentials.password());
-                secretaryScreenView.showRegisterPatientSuccess();
+            UserCredentials userCred = secretaryScreenView.registerPatientPrompt();
+            PatientData patient = patientManager.createPatient(userCred.username(), userCred.password());
+            if (patient == null) {
+                secretaryScreenView.showFailedToRegisterPatientError();
             } else {
-                secretaryScreenView.showRegisterPatientError();
+                secretaryScreenView.showRegisterPatientSuccess();
             }
-
         };
+//        return (x) -> {
+//            UserCredentials userCredentials = secretaryScreenView.registerPatientAccount();
+//            if (!patientManager.doesUserExist(userCredentials.username()) &&
+//                    !doctorManager.doesUserExist(userCredentials.username()) &&
+//                    !adminManager.doesUserExist(userCredentials.username()) &&
+//                    !secretaryManager.doesUserExist(userCredentials.username())) {
+//                patientManager.createPatient(userCredentials.username(), userCredentials.password());
+//                secretaryScreenView.showRegisterPatientSuccess();
+//            } else {
+//                secretaryScreenView.showRegisterPatientError();
+//            }
+//        };
     }
 
     private Command deletePatient() {

--- a/src/controllers/SignInController.java
+++ b/src/controllers/SignInController.java
@@ -9,6 +9,7 @@ import presenters.screenViews.SignInScreenView;
 import useCases.*;
 
 import java.util.LinkedHashMap;
+import java.util.regex.Pattern;
 
 /**
  * Controller class that processes the commands that users pass in before signing in to their accounts.
@@ -53,32 +54,58 @@ public class SignInController extends TerminalController {
         return commands;
     }
 
-    private void adminSignIn(String username, String password) {
-        AdminData adminData = adminManager.signIn(username, password);
-        AdminController adminController = new AdminController(getContext(), adminData);
-        signInScreenView.showSuccessLogin(adminData.getUsername());
-        changeCurrentController(adminController);
+    private boolean adminSignIn(String username, String password) {
+        if (adminManager.canSignIn(username, password)) {
+            AdminData adminData = adminManager.signIn(username, password);
+            AdminController adminController = new AdminController(getContext(), adminData);
+            signInScreenView.showSuccessLogin(adminData.getUsername());
+            changeCurrentController(adminController);
+            return true;
+        }
+        return false;
     }
 
-    private void patientSignIn(String username, String password) {
-        PatientData patientData = patientManager.signIn(username, password);
-        PatientController patientController = new PatientController(getContext(), patientData);
-        signInScreenView.showSuccessLogin(patientData.getUsername());
-        changeCurrentController(patientController);
+    private boolean patientSignIn(String username, String password) {
+        if (patientManager.canSignIn(username, password)) {
+            PatientData patientData = patientManager.signIn(username, password);
+            PatientController patientController = new PatientController(getContext(), patientData);
+            signInScreenView.showSuccessLogin(patientData.getUsername());
+            changeCurrentController(patientController);
+            return true;
+        }
+        return false;
     }
 
-    private void doctorSignIn(String username, String password) {
-        DoctorData doctorData = doctorManager.signIn(username, password);
-        DoctorController doctorController = new DoctorController(getContext(), doctorData);
-        signInScreenView.showSuccessLogin(doctorData.getUsername());
-        changeCurrentController(doctorController);
+    private boolean doctorSignIn(String username, String password) {
+        if (doctorManager.canSignIn(username, password)) {
+            DoctorData doctorData = doctorManager.signIn(username, password);
+            DoctorController doctorController = new DoctorController(getContext(), doctorData);
+            signInScreenView.showSuccessLogin(doctorData.getUsername());
+            changeCurrentController(doctorController);
+            return true;
+        }
+        return false;
     }
 
-    private void secretarySignIn(String username, String password) {
-        SecretaryData secretaryData = secretaryManager.signIn(username, password);
-        SecretaryController secretaryController = new SecretaryController(getContext(), secretaryData);
-        signInScreenView.showSuccessLogin(secretaryData.getUsername());
-        changeCurrentController(secretaryController);
+    private boolean secretarySignIn(String username, String password) {
+        if (secretaryManager.canSignIn(username, password)) {
+            SecretaryData secretaryData = secretaryManager.signIn(username, password);
+            SecretaryController secretaryController = new SecretaryController(getContext(), secretaryData);
+            signInScreenView.showSuccessLogin(secretaryData.getUsername());
+            changeCurrentController(secretaryController);
+            return true;
+        }
+        return false;
+    }
+
+    private void signIn(String username, String password) {
+        boolean signedIn = adminSignIn(username, password) |
+                            patientSignIn(username, password) |
+                            doctorSignIn(username, password) |
+                            secretarySignIn(username, password);
+        if (!signedIn) {
+            signInScreenView.showLoginError();
+        }
     }
 
     private Command SignInCommand() {
@@ -87,17 +114,7 @@ public class SignInController extends TerminalController {
             String username = userCredentials.username();
             String password = userCredentials.password();
 
-            if (adminManager.canSignIn(username, password)) {
-                adminSignIn(username, password);
-            } else if (patientManager.canSignIn(username, password)) {
-                patientSignIn(username, password);
-            } else if (doctorManager.canSignIn(username, password)) {
-                doctorSignIn(username, password);
-            } else if (secretaryManager.canSignIn(username, password)) {
-                secretarySignIn(username, password);
-            } else {
-                signInScreenView.showLoginError();
-            }
+            signIn(username, password);
         };
     }
 

--- a/src/controllers/SignInController.java
+++ b/src/controllers/SignInController.java
@@ -99,9 +99,9 @@ public class SignInController extends TerminalController {
     }
 
     private void signIn(String username, String password) {
-        boolean signedIn = adminSignIn(username, password) |
-                            patientSignIn(username, password) |
-                            doctorSignIn(username, password) |
+        boolean signedIn = adminSignIn(username, password) ||
+                            patientSignIn(username, password) ||
+                            doctorSignIn(username, password) ||
                             secretarySignIn(username, password);
         if (!signedIn) {
             signInScreenView.showLoginError();

--- a/src/presenters/screenViews/AdminScreenView.java
+++ b/src/presenters/screenViews/AdminScreenView.java
@@ -52,17 +52,19 @@ public class AdminScreenView extends UserScreenView {
     }
 
     /**
-     * Show a failed to create user error that is thrown when username is already used.
+     * Show a failed to create user error that is thrown when username does not start with correct letter
+     * or when username is already used.
      */
-    public void showFailedToRegisterUserError() {
-        errorMessage("Failed to register user account: username already in use");
+    public void showFailedToRegisterUserError(String userType) {
+        errorMessage("Failed to register " + userType + " account: username must start with the lowercase " +
+                "letter '" + userType.charAt(0) + "' and be 6 characters long or username is already in use.");
     }
 
     /**
      * Show success message when admin successfully creates another user.
      */
-    public void showRegisterUserSuccess() {
-        successMessage("Created user account successfully!");
+    public void showRegisterUserSuccess(String userType) {
+        successMessage("Created " + userType + " account successfully!");
     }
 
     /**

--- a/src/presenters/screenViews/AdminScreenView.java
+++ b/src/presenters/screenViews/AdminScreenView.java
@@ -52,12 +52,20 @@ public class AdminScreenView extends UserScreenView {
     }
 
     /**
-     * Show a failed to create user error that is thrown when username does not start with correct letter
-     * or when username is already used.
+     * Show a failed to create user error that is thrown when username or password is in an incorrect format.
      */
-    public void showFailedToRegisterUserError(String userType) {
-        errorMessage("Failed to register " + userType + " account: username must start with the lowercase " +
-                "letter '" + userType.charAt(0) + "' and be 6 characters long or username is already in use.");
+    public void showIncorrectFormatError(String userType) {
+        errorMessage("Failed to register " + userType + " account. Make sure:" +
+                "\n1. Username starts with the lowercase letter '" + userType.charAt(0) + "'" +
+                "\n2. Username is 6 characters long" +
+                "\n3. Password is 8 characters long");
+    }
+
+    /**
+     * Show a failed to create user error that is thrown when username is already in use.
+     */
+    public void showUsernameInUseError(String userType) {
+        errorMessage("Failed to register " + userType + " account: username is already in use.");
     }
 
     /**

--- a/src/presenters/screenViews/AdminScreenView.java
+++ b/src/presenters/screenViews/AdminScreenView.java
@@ -56,9 +56,8 @@ public class AdminScreenView extends UserScreenView {
      */
     public void showIncorrectFormatError(String userType) {
         errorMessage("Failed to register " + userType + " account. Make sure:" +
-                "\n1. Username starts with the lowercase letter '" + userType.charAt(0) + "'" +
-                "\n2. Username is 6 characters long" +
-                "\n3. Password is 8 characters long");
+                "\n1. Username is 6 characters long and only contains letters and numbers." +
+                "\n2. Password is 8 characters long.");
     }
 
     /**

--- a/src/presenters/screenViews/SecretaryScreenView.java
+++ b/src/presenters/screenViews/SecretaryScreenView.java
@@ -39,11 +39,9 @@ public class SecretaryScreenView extends UserScreenView {
      * Show a failed to create patient error that is thrown when username or password is in an incorrect format.
      */
     public void showIncorrectPatientFormatError() {
-        errorMessage("""
-                Failed to register patient account. Make sure:
-                1. Username starts with the lowercase letter 'p'
-                2. Username is 6 characters long
-                3. Password is 8 characters long""");
+        errorMessage("Failed to register patient account. Make sure:" +
+                "\n1. Username is 6 characters long and only contains letters and numbers." +
+                "\n2. Password is 8 characters long.");
     }
 
     /**

--- a/src/presenters/screenViews/SecretaryScreenView.java
+++ b/src/presenters/screenViews/SecretaryScreenView.java
@@ -36,11 +36,21 @@ public class SecretaryScreenView extends UserScreenView {
     }
 
     /**
-     * Show error message when patient cannot be created due to non-unique username.
+     * Show a failed to create patient error that is thrown when username or password is in an incorrect format.
      */
-    public void showFailedToRegisterPatientError() {
-        errorMessage("Failed to register patient account: username must start with the lowercase " +
-                        "letter 'p' and be 6 characters long or username is already in use.");
+    public void showIncorrectPatientFormatError() {
+        errorMessage("""
+                Failed to register patient account. Make sure:
+                1. Username starts with the lowercase letter 'p'
+                2. Username is 6 characters long
+                3. Password is 8 characters long""");
+    }
+
+    /**
+     * Show a failed to create patient error that is thrown when username is already in use.
+     */
+    public void showPatientUsernameInUseError() {
+        errorMessage("Failed to register patient account: username is already in use.");
     }
 
     /**

--- a/src/presenters/screenViews/SecretaryScreenView.java
+++ b/src/presenters/screenViews/SecretaryScreenView.java
@@ -24,7 +24,7 @@ public class SecretaryScreenView extends UserScreenView {
      * Create a new patient prompt.
      * @return UserCredentials containing username and password.
      */
-    public UserCredentials registerPatientAccount() {
+    public UserCredentials registerPatientPrompt() {
         return registerAccountPrompt("patient");
     }
 
@@ -32,14 +32,15 @@ public class SecretaryScreenView extends UserScreenView {
      * Show success message when patient is created successfully.
      */
     public void showRegisterPatientSuccess() {
-        successMessage("Patient create successfully!");
+        successMessage("Created patient account successfully!");
     }
 
     /**
      * Show error message when patient cannot be created due to non-unique username.
      */
-    public void showRegisterPatientError() {
-        errorMessage("Could not create patient: a user with this username already exists");
+    public void showFailedToRegisterPatientError() {
+        errorMessage("Failed to register patient account: username must start with the lowercase " +
+                        "letter 'p' and be 6 characters long or username is already in use.");
     }
 
     /**

--- a/src/useCases/AdminManager.java
+++ b/src/useCases/AdminManager.java
@@ -30,12 +30,17 @@ public class AdminManager extends UserManager<Admin>{
      * @return Admin data if sign in successful, if username exists in the database, return null.
      */
     public AdminData createAdmin(String username, String password) {
-        Admin admin = new Admin(username, password);
-        if (Pattern.matches("^a[a-zA-Z0-9]{5,}$", username) && adminDatabase.add(admin) != null) {
-            admin.setContactInfoId(newContactInDatabase());
-            return new AdminData(admin);
+        if (Pattern.matches("^a[a-zA-Z0-9]{5,}$", username) && Pattern.matches("^.{8,}$", password)) {
+            Admin admin = new Admin(username, password);
+            if (adminDatabase.add(admin) != null) {
+                admin.setContactInfoId(newContactInDatabase());
+                return new AdminData(admin);
+            } else {
+                return null;
+            }
+        } else {
+            throw new IllegalArgumentException();
         }
-        return null;
     }
 
     /**

--- a/src/useCases/AdminManager.java
+++ b/src/useCases/AdminManager.java
@@ -30,7 +30,7 @@ public class AdminManager extends UserManager<Admin>{
      * @return Admin data if sign in successful, if username exists in the database, return null.
      */
     public AdminData createAdmin(String username, String password) {
-        if (Pattern.matches("^a[a-zA-Z0-9]{5,}$", username) && Pattern.matches("^.{8,}$", password)) {
+        if (Pattern.matches("^[a-zA-Z0-9]{6,}$", username) && Pattern.matches("^.{8,}$", password)) {
             Admin admin = new Admin(username, password);
             if (adminDatabase.add(admin) != null) {
                 admin.setContactInfoId(newContactInDatabase());

--- a/src/useCases/AdminManager.java
+++ b/src/useCases/AdminManager.java
@@ -5,8 +5,6 @@ import database.DataMapperGateway;
 import database.Database;
 import entities.Admin;
 
-import java.util.regex.Pattern;
-
 /**
  * Use case class for handling operations and data of admin users.
  */
@@ -30,7 +28,7 @@ public class AdminManager extends UserManager<Admin>{
      * @return Admin data if sign in successful, if username exists in the database, return null.
      */
     public AdminData createAdmin(String username, String password) {
-        if (Pattern.matches("^[a-zA-Z0-9]{6,}$", username) && Pattern.matches("^.{8,}$", password)) {
+        if (super.regexCheck(username, password)) {
             Admin admin = new Admin(username, password);
             if (adminDatabase.add(admin) != null) {
                 admin.setContactInfoId(newContactInDatabase());

--- a/src/useCases/AdminManager.java
+++ b/src/useCases/AdminManager.java
@@ -5,6 +5,8 @@ import database.DataMapperGateway;
 import database.Database;
 import entities.Admin;
 
+import java.util.regex.Pattern;
+
 /**
  * Use case class for handling operations and data of admin users.
  */
@@ -27,9 +29,9 @@ public class AdminManager extends UserManager<Admin>{
      * @param password password of new account.
      * @return Admin data if sign in successful, if username exists in the database, return null.
      */
-    public AdminData createAdmin(String username, String password){
+    public AdminData createAdmin(String username, String password) {
         Admin admin = new Admin(username, password);
-        if (adminDatabase.add(admin) != null) {
+        if (Pattern.matches("^a[a-zA-Z0-9]{5,}$", username) && adminDatabase.add(admin) != null) {
             admin.setContactInfoId(newContactInDatabase());
             return new AdminData(admin);
         }

--- a/src/useCases/DoctorManager.java
+++ b/src/useCases/DoctorManager.java
@@ -5,8 +5,6 @@ import database.DataMapperGateway;
 import database.Database;
 import entities.Doctor;
 
-import java.util.regex.Pattern;
-
 /**
  * Use case class for handling operations and data of doctor users.
  */
@@ -32,7 +30,7 @@ public class DoctorManager extends UserManager<Doctor> {
      * otherwise returns null.
      */
     public DoctorData createDoctor(String username, String password) {
-        if (Pattern.matches("^[a-zA-Z0-9]{6,}$", username) && Pattern.matches("^.{8,}$", password)) {
+        if (super.regexCheck(username, password)) {
             Doctor doctor = new Doctor(username, password);
             // Commented code is pending implementation in phase 2
             //        database.getClinic().getClinicHours().forEach(doctor::addAvailability);

--- a/src/useCases/DoctorManager.java
+++ b/src/useCases/DoctorManager.java
@@ -32,7 +32,7 @@ public class DoctorManager extends UserManager<Doctor> {
      * otherwise returns null.
      */
     public DoctorData createDoctor(String username, String password) {
-        if (Pattern.matches("^d[a-zA-Z0-9]{5,}$", username) && Pattern.matches("^.{8,}$", password)) {
+        if (Pattern.matches("^[a-zA-Z0-9]{6,}$", username) && Pattern.matches("^.{8,}$", password)) {
             Doctor doctor = new Doctor(username, password);
             // Commented code is pending implementation in phase 2
             //        database.getClinic().getClinicHours().forEach(doctor::addAvailability);

--- a/src/useCases/DoctorManager.java
+++ b/src/useCases/DoctorManager.java
@@ -5,6 +5,8 @@ import database.DataMapperGateway;
 import database.Database;
 import entities.Doctor;
 
+import java.util.regex.Pattern;
+
 /**
  * Use case class for handling operations and data of doctor users.
  */
@@ -33,7 +35,7 @@ public class DoctorManager extends UserManager<Doctor> {
         Doctor doctor = new Doctor(username, password);
         // Commented code is pending implementation in phase 2
 //        database.getClinic().getClinicHours().forEach(doctor::addAvailability);
-        if (doctorDatabase.add(doctor) != null) {
+        if (Pattern.matches("^d[a-zA-Z0-9]{5,}$", username) && doctorDatabase.add(doctor) != null) {
             doctor.setContactInfoId(newContactInDatabase());
             return new DoctorData(doctor);
         }

--- a/src/useCases/DoctorManager.java
+++ b/src/useCases/DoctorManager.java
@@ -32,14 +32,19 @@ public class DoctorManager extends UserManager<Doctor> {
      * otherwise returns null.
      */
     public DoctorData createDoctor(String username, String password) {
-        Doctor doctor = new Doctor(username, password);
-        // Commented code is pending implementation in phase 2
-//        database.getClinic().getClinicHours().forEach(doctor::addAvailability);
-        if (Pattern.matches("^d[a-zA-Z0-9]{5,}$", username) && doctorDatabase.add(doctor) != null) {
-            doctor.setContactInfoId(newContactInDatabase());
-            return new DoctorData(doctor);
+        if (Pattern.matches("^d[a-zA-Z0-9]{5,}$", username) && Pattern.matches("^.{8,}$", password)) {
+            Doctor doctor = new Doctor(username, password);
+            // Commented code is pending implementation in phase 2
+            //        database.getClinic().getClinicHours().forEach(doctor::addAvailability);
+            if (doctorDatabase.add(doctor) != null) {
+                doctor.setContactInfoId(newContactInDatabase());
+                return new DoctorData(doctor);
+            } else {
+                return null;
+            }
+        } else {
+            throw new IllegalArgumentException();
         }
-        return null;
     }
 
     /**

--- a/src/useCases/PatientManager.java
+++ b/src/useCases/PatientManager.java
@@ -5,6 +5,8 @@ import database.DataMapperGateway;
 import database.Database;
 import entities.Patient;
 
+import java.util.regex.Pattern;
+
 /**
  * Use case class for handling operations and data of patient users.
  */
@@ -30,7 +32,7 @@ public class PatientManager extends UserManager<Patient> {
      */
     public PatientData createPatient(String username, String password) {
         Patient patient = new Patient(username, password);
-        if (patientDatabase.add(patient) != null) {
+        if (Pattern.matches("^p[a-zA-Z0-9]{5,}$", username) && patientDatabase.add(patient) != null) {
             patient.setContactInfoId(newContactInDatabase());
             return new PatientData(patient);
         }

--- a/src/useCases/PatientManager.java
+++ b/src/useCases/PatientManager.java
@@ -33,7 +33,7 @@ public class PatientManager extends UserManager<Patient> {
      * null if username exists in database.
      */
     public PatientData createPatient(String username, String password) {
-        if (Pattern.matches("^p[a-zA-Z0-9]{5,}$", username) && Pattern.matches("^.{8,}$", password)) {
+        if (Pattern.matches("^[a-zA-Z0-9]{6,}$", username) && Pattern.matches("^.{8,}$", password)) {
             Patient patient = new Patient(username, password);
             if (patientDatabase.add(patient) != null) {
                 patient.setContactInfoId(newContactInDatabase());

--- a/src/useCases/PatientManager.java
+++ b/src/useCases/PatientManager.java
@@ -1,13 +1,9 @@
 package useCases;
 
-import dataBundles.AdminData;
 import dataBundles.PatientData;
 import database.DataMapperGateway;
 import database.Database;
-import entities.Admin;
 import entities.Patient;
-
-import java.util.regex.Pattern;
 
 /**
  * Use case class for handling operations and data of patient users.
@@ -33,7 +29,7 @@ public class PatientManager extends UserManager<Patient> {
      * null if username exists in database.
      */
     public PatientData createPatient(String username, String password) {
-        if (Pattern.matches("^[a-zA-Z0-9]{6,}$", username) && Pattern.matches("^.{8,}$", password)) {
+        if (super.regexCheck(username, password)) {
             Patient patient = new Patient(username, password);
             if (patientDatabase.add(patient) != null) {
                 patient.setContactInfoId(newContactInDatabase());

--- a/src/useCases/PatientManager.java
+++ b/src/useCases/PatientManager.java
@@ -1,8 +1,10 @@
 package useCases;
 
+import dataBundles.AdminData;
 import dataBundles.PatientData;
 import database.DataMapperGateway;
 import database.Database;
+import entities.Admin;
 import entities.Patient;
 
 import java.util.regex.Pattern;
@@ -31,12 +33,17 @@ public class PatientManager extends UserManager<Patient> {
      * null if username exists in database.
      */
     public PatientData createPatient(String username, String password) {
-        Patient patient = new Patient(username, password);
-        if (Pattern.matches("^p[a-zA-Z0-9]{5,}$", username) && patientDatabase.add(patient) != null) {
-            patient.setContactInfoId(newContactInDatabase());
-            return new PatientData(patient);
+        if (Pattern.matches("^p[a-zA-Z0-9]{5,}$", username) && Pattern.matches("^.{8,}$", password)) {
+            Patient patient = new Patient(username, password);
+            if (patientDatabase.add(patient) != null) {
+                patient.setContactInfoId(newContactInDatabase());
+                return new PatientData(patient);
+            } else {
+                return null;
+            }
+        } else {
+            throw new IllegalArgumentException();
         }
-        return null;
     }
 
     /**

--- a/src/useCases/SecretaryManager.java
+++ b/src/useCases/SecretaryManager.java
@@ -1,8 +1,10 @@
 package useCases;
 
+import dataBundles.AdminData;
 import dataBundles.SecretaryData;
 import database.DataMapperGateway;
 import database.Database;
+import entities.Admin;
 import entities.Secretary;
 
 import java.util.regex.Pattern;
@@ -31,12 +33,17 @@ public class SecretaryManager extends UserManager<Secretary> {
      * null if username exists in database.
      */
     public SecretaryData createSecretary(String username, String password) {
-        Secretary secretary = new Secretary(username, password);
-        if (Pattern.matches("^s[a-zA-Z0-9]{5,}$", username) && secretaryDatabase.add(secretary) != null) {
-            secretary.setContactInfoId(newContactInDatabase());
-            return new SecretaryData(secretary);
+        if (Pattern.matches("^s[a-zA-Z0-9]{5,}$", username) && Pattern.matches("^.{8,}$", password)) {
+            Secretary secretary = new Secretary(username, password);
+            if (secretaryDatabase.add(secretary) != null) {
+                secretary.setContactInfoId(newContactInDatabase());
+                return new SecretaryData(secretary);
+            } else {
+                return null;
+            }
+        } else {
+            throw new IllegalArgumentException();
         }
-        return null;
     }
 
     /**

--- a/src/useCases/SecretaryManager.java
+++ b/src/useCases/SecretaryManager.java
@@ -5,6 +5,8 @@ import database.DataMapperGateway;
 import database.Database;
 import entities.Secretary;
 
+import java.util.regex.Pattern;
+
 /**
  * Use case class for handling operations and data of secretary users.
  */
@@ -30,7 +32,7 @@ public class SecretaryManager extends UserManager<Secretary> {
      */
     public SecretaryData createSecretary(String username, String password) {
         Secretary secretary = new Secretary(username, password);
-        if (secretaryDatabase.add(secretary) != null) {
+        if (Pattern.matches("^s[a-zA-Z0-9]{5,}$", username) && secretaryDatabase.add(secretary) != null) {
             secretary.setContactInfoId(newContactInDatabase());
             return new SecretaryData(secretary);
         }

--- a/src/useCases/SecretaryManager.java
+++ b/src/useCases/SecretaryManager.java
@@ -33,7 +33,7 @@ public class SecretaryManager extends UserManager<Secretary> {
      * null if username exists in database.
      */
     public SecretaryData createSecretary(String username, String password) {
-        if (Pattern.matches("^s[a-zA-Z0-9]{5,}$", username) && Pattern.matches("^.{8,}$", password)) {
+        if (Pattern.matches("^[a-zA-Z0-9]{6,}$", username) && Pattern.matches("^.{8,}$", password)) {
             Secretary secretary = new Secretary(username, password);
             if (secretaryDatabase.add(secretary) != null) {
                 secretary.setContactInfoId(newContactInDatabase());

--- a/src/useCases/SecretaryManager.java
+++ b/src/useCases/SecretaryManager.java
@@ -1,13 +1,9 @@
 package useCases;
 
-import dataBundles.AdminData;
 import dataBundles.SecretaryData;
 import database.DataMapperGateway;
 import database.Database;
-import entities.Admin;
 import entities.Secretary;
-
-import java.util.regex.Pattern;
 
 /**
  * Use case class for handling operations and data of secretary users.
@@ -33,7 +29,7 @@ public class SecretaryManager extends UserManager<Secretary> {
      * null if username exists in database.
      */
     public SecretaryData createSecretary(String username, String password) {
-        if (Pattern.matches("^[a-zA-Z0-9]{6,}$", username) && Pattern.matches("^.{8,}$", password)) {
+        if (super.regexCheck(username, password)) {
             Secretary secretary = new Secretary(username, password);
             if (secretaryDatabase.add(secretary) != null) {
                 secretary.setContactInfoId(newContactInDatabase());

--- a/src/useCases/UserManager.java
+++ b/src/useCases/UserManager.java
@@ -7,6 +7,7 @@ import entities.Contact;
 import entities.User;
 
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 /**
  * Abstract use case class for handling operations and data of users of all types.
@@ -45,6 +46,16 @@ public abstract class UserManager<T extends User> {
             return true;
         }
         return false;
+    }
+
+    /***
+     * Checks if username and password adhere to regex pattern.
+     * @param username username of new account.
+     * @param password password of new account.
+     * @return boolean whether or not the username and password adhere to the regex pattern.
+     */
+    public boolean regexCheck(String username, String password) {
+        return Pattern.matches("^[a-zA-Z0-9]{6,}$", username) && Pattern.matches("^.{8,}$", password);
     }
 
     /**


### PR DESCRIPTION
Implemented the feature that does not allow the creation of user accounts without follow the regex format we have required for usernames and password. In order to create a user account, the username must contain 6 characters and be completely alphanumeric (no special characters or spaces) and the password must contain 8 characters which can be anything. Also, if a user account does not get created, the reason is provided: either the format does not follow the regex or the username is already taken.