### PR TITLE
refactor: implemented menu controller and menu loaded patient controller abstract classes that store commands specific to menus

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,4 +3,9 @@
   <component name="ProjectRootManager" version="2" project-jdk-name="corretto-11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
+  <component name="SwUserDefinedSpecifications">
+    <option name="specTypeByUrl">
+      <map />
+    </option>
+  </component>
 </project>

--- a/src/controllers/AdminUserManagementController.java
+++ b/src/controllers/AdminUserManagementController.java
@@ -7,14 +7,14 @@ import presenters.response.UserCredentials;
 import presenters.screenViews.AdminScreenView;
 import useCases.*;
 
+import java.awt.*;
 import java.util.LinkedHashMap;
 
 /**
  * Controller class that handles the creation and deletion of users by an admin.
  */
-public class AdminUserManagementController extends TerminalController {
+public class AdminUserManagementController extends MenuController {
 
-    private final AdminController previousController;
     private final AdminData adminData;
     private final AdminScreenView adminScreenView = new AdminScreenView();
     private final PatientManager patientManager;
@@ -31,8 +31,7 @@ public class AdminUserManagementController extends TerminalController {
      * @param adminData AdminData - a data containing the ID and attributes of the current loaded admin user.
      */
     public AdminUserManagementController(Context context, AdminController previousController, AdminData adminData) {
-        super(context);
-        this.previousController = previousController;
+        super(context, previousController);
         this.adminData = adminData;
         this.patientManager = new PatientManager(getDatabase());
         this.secretaryManager = new SecretaryManager(getDatabase());
@@ -58,7 +57,6 @@ public class AdminUserManagementController extends TerminalController {
     @Override
     public LinkedHashMap<String, Command> AllCommands (){
         LinkedHashMap<String, Command> commands = new LinkedHashMap<>();
-        commands.put("back", Back(previousController));
         commands.put("create admin", CreateAdmin());
         commands.put("create secretary", CreateSecretary());
         commands.put("create doctor", CreateDoctor());

--- a/src/controllers/ClinicController.java
+++ b/src/controllers/ClinicController.java
@@ -9,11 +9,10 @@ import java.util.LinkedHashMap;
 /**
  * Controller class that processes the commands that an admin performs on a clinic's information.
  */
-public class ClinicController extends TerminalController {
+public class ClinicController extends MenuController {
 
     private final ClinicScreenView clinicScreenView;
     private final ClinicManager clinicManager;
-    private final UserController<Admin> previousController;
 
     /**
      * Creates a clinic controller object that handles the commands an admin performs on the clinic information.
@@ -23,10 +22,9 @@ public class ClinicController extends TerminalController {
      *                           clinic controller object.
      */
     public ClinicController(Context context, UserController<Admin> previousController) {
-        super(context);
+        super(context, previousController);
         this.clinicManager = new ClinicManager(getDatabase());
         this.clinicScreenView = new ClinicScreenView();
-        this.previousController = previousController;
     }
 
     @Override
@@ -45,7 +43,6 @@ public class ClinicController extends TerminalController {
         commands.put("change clinic email", ChangeClinicEmail());
         commands.put("change clinic phone number", ChangeClinicPhoneNumber());
         commands.put("change clinic address", ChangeClinicAddress());
-        commands.put("back", Back(previousController));
         commands.putAll(super.AllCommands());
         return commands;
     }

--- a/src/controllers/ContactController.java
+++ b/src/controllers/ContactController.java
@@ -4,18 +4,18 @@ import dataBundles.ContactData;
 import presenters.screenViews.ContactScreenView;
 import useCases.ContactManager;
 
+import java.awt.*;
 import java.time.LocalDate;
 import java.util.LinkedHashMap;
 
 /**
  * Controller class that processes the commands that a user performs on their contact information.
  */
-public class ContactController extends TerminalController {
+public class ContactController extends MenuController {
 
     private final ContactData contactData;
     private final ContactScreenView contactScreenView;
     private final ContactManager contactManager;
-    private final UserController<?> previousController;
 
     /**
      * Creates a contact controller object that handles the commands a user performs on their contact information.
@@ -28,8 +28,7 @@ public class ContactController extends TerminalController {
      */
     public ContactController(Context context, UserController<?> previousController,
                              ContactData contactData) {
-        super(context);
-        this.previousController = previousController;
+        super(context, previousController);
         this.contactData = contactData;
         this.contactManager = new ContactManager(getDatabase());
         this.contactScreenView = new ContactScreenView();
@@ -57,7 +56,6 @@ public class ContactController extends TerminalController {
         commands.put("change emergency contact email", ChangeEmergencyContactEmail());
         commands.put("change emergency contact phone number", ChangeEmergencyContactPhoneNumber());
         commands.put("change emergency contact relationship", ChangeEmergencyContactRelationship());
-        commands.put("back", Back(previousController));
         commands.putAll(super.AllCommands());
         return commands;
     }

--- a/src/controllers/DoctorLoadedPatientController.java
+++ b/src/controllers/DoctorLoadedPatientController.java
@@ -13,7 +13,7 @@ import java.util.LinkedHashMap;
 /**
  * Controller class that process the commands a doctor would use on a specific patient that they loaded.
  */
-public class DoctorLoadedPatientController extends TerminalController {
+public class DoctorLoadedPatientController extends MenuController {
 
     private final PatientData patientData;
     private final DoctorData doctorData;
@@ -36,7 +36,7 @@ public class DoctorLoadedPatientController extends TerminalController {
      */
     public DoctorLoadedPatientController(Context context, DoctorController previousController, DoctorData doctorData,
                                          PatientData patientData) {
-        super(context);
+        super(context, previousController);
         this.patientData = patientData;
         this.doctorData = doctorData;
         this.previousController = previousController;
@@ -58,7 +58,6 @@ public class DoctorLoadedPatientController extends TerminalController {
         PrescriptionListCommands prescriptionListCommands = new PrescriptionListCommands(getDatabase(), patientData);
         LinkedHashMap<String, Command> commands = new LinkedHashMap<>();
         commands.put("unload patient", Back(previousController));
-        commands.put("back", Back(previousController));
         commands.put("view appointments", ViewPatientAppointments());
         commands.put("view reports", ViewPatientReports());
         commands.put("create report", CreatePatientReport());

--- a/src/controllers/DoctorLoadedPatientController.java
+++ b/src/controllers/DoctorLoadedPatientController.java
@@ -13,13 +13,12 @@ import java.util.LinkedHashMap;
 /**
  * Controller class that process the commands a doctor would use on a specific patient that they loaded.
  */
-public class DoctorLoadedPatientController extends MenuController {
+public class DoctorLoadedPatientController extends MenuLoadedPatientController {
 
     private final PatientData patientData;
     private final DoctorData doctorData;
     private final PrescriptionManager prescriptionManager;
     private final DoctorScreenView doctorView = new DoctorScreenView();
-    private final DoctorController previousController;
     private final ReportManager reportManager;
     private final DoctorManager doctorManager;
     private final ContactManager contactManager;
@@ -39,7 +38,6 @@ public class DoctorLoadedPatientController extends MenuController {
         super(context, previousController);
         this.patientData = patientData;
         this.doctorData = doctorData;
-        this.previousController = previousController;
         this.prescriptionManager = new PrescriptionManager(getDatabase());
         this.reportManager = new ReportManager(getDatabase());
         this.doctorManager = new DoctorManager(getDatabase());
@@ -57,7 +55,6 @@ public class DoctorLoadedPatientController extends MenuController {
     public LinkedHashMap<String, Command> AllCommands() {
         PrescriptionListCommands prescriptionListCommands = new PrescriptionListCommands(getDatabase(), patientData);
         LinkedHashMap<String, Command> commands = new LinkedHashMap<>();
-        commands.put("unload patient", Back(previousController));
         commands.put("view appointments", ViewPatientAppointments());
         commands.put("view reports", ViewPatientReports());
         commands.put("create report", CreatePatientReport());

--- a/src/controllers/MenuController.java
+++ b/src/controllers/MenuController.java
@@ -2,10 +2,16 @@ package controllers;
 
 import java.util.LinkedHashMap;
 
+/**
+ * Controller class for processing commands that a user passes in while on a menu screen.
+ */
 abstract public class MenuController extends TerminalController {
 
     private final UserController<?> previousController;
 
+    /**
+     * Creates a new controller for handling the state of when a user on a menu screen.
+     */
     public MenuController(Context context, UserController<?> previousController) {
         super(context);
         this.previousController = previousController;

--- a/src/controllers/MenuController.java
+++ b/src/controllers/MenuController.java
@@ -1,0 +1,31 @@
+package controllers;
+
+import java.util.LinkedHashMap;
+
+abstract public class MenuController extends TerminalController {
+
+    private final UserController<?> previousController;
+
+    public MenuController(Context context, UserController<?> previousController) {
+        super(context);
+        this.previousController = previousController;
+    }
+
+    /**
+     * Creates a Linked hashmap of all string representations of menu commands mapped to the method that each
+     * command calls.
+     * @return LinkedHashMap<String, Command> - ordered HashMap of strings mapped to their respective menu commands.
+     */
+    @Override
+    public LinkedHashMap<String, Command> AllCommands() {
+        LinkedHashMap<String, Command> commands = new LinkedHashMap<>();
+        commands.put("back", Back(previousController));
+        commands.putAll(super.AllCommands());
+        return commands;
+    }
+
+    protected Command Back(TerminalController previousController) {
+        return (x) -> changeCurrentController(previousController);
+    }
+
+}

--- a/src/controllers/MenuLoadedPatientController.java
+++ b/src/controllers/MenuLoadedPatientController.java
@@ -1,0 +1,34 @@
+package controllers;
+
+import java.util.LinkedHashMap;
+
+/**
+ * Controller class for processing commands that a user passes in while having loaded a patient.
+ */
+abstract public class MenuLoadedPatientController extends MenuController {
+
+    private final UserController<?> previousController;
+
+    /**
+     * Creates a new controller for handling the state of when a user has loaded a patient.
+     */
+    public MenuLoadedPatientController(Context context, UserController<?> previousController) {
+        super(context, previousController);
+        this.previousController = previousController;
+    }
+
+    /**
+     * Creates a Linked hashmap of all string representations of menu loaded patient commands mapped to the method that
+     * each command calls.
+     * @return LinkedHashMap<String, Command> - ordered HashMap of strings mapped to their respective menu loaded
+     * patient commands.
+     */
+    @Override
+    public LinkedHashMap<String, Command> AllCommands() {
+        LinkedHashMap<String, Command> commands = new LinkedHashMap<>();
+        commands.put("unload patient", Back(previousController));
+        commands.putAll(super.AllCommands());
+        return commands;
+    }
+
+}

--- a/src/controllers/SecretaryLoadedPatientController.java
+++ b/src/controllers/SecretaryLoadedPatientController.java
@@ -11,11 +11,11 @@ import java.util.LinkedHashMap;
 /**
  * Controller class that process the commands a secretary would use on a specific patient that they loaded.
  */
-public class SecretaryLoadedPatientController extends TerminalController {
+public class SecretaryLoadedPatientController extends MenuController {
 
     private final PatientData patientData;
-    private final SecretaryController previousController;
     private final PatientManager patientManager;
+    private final SecretaryController previousController;
     private final SecretaryScreenView secretaryScreenView = new SecretaryScreenView();
 
     /* PHASE 2 ATTRIBUTES
@@ -27,15 +27,15 @@ public class SecretaryLoadedPatientController extends TerminalController {
      * Creates a new controller for handling the state of the program when a doctor has loaded a specific patient.
      * @param context Context - a reference to the context object, which stores the current controller and allows for
      *                switching between controllers.
-     * @param secretaryController SecretaryController - the previous controller object, allowing you to easily go back.
+     * @param previousController SecretaryController - the previous controller object, allowing you to easily go back.
      * @param patientData PatientData - a data containing the ID and attributes of the current loaded
      *                    patient user.
      */
-    public SecretaryLoadedPatientController(Context context, SecretaryController secretaryController,
+    public SecretaryLoadedPatientController(Context context, SecretaryController previousController,
                                             PatientData patientData) {
-        super(context);
-        this.previousController = secretaryController;
+        super(context, previousController);
         this.patientData = patientData;
+        this.previousController = previousController;
         this.patientManager = new PatientManager(getDatabase());
 
         /* PHASE 2 INSTANTIATIONS
@@ -56,7 +56,6 @@ public class SecretaryLoadedPatientController extends TerminalController {
         PrescriptionListCommands prescriptionListCommands = new PrescriptionListCommands(getDatabase(), patientData);
         commands.put("change patient password", ChangePatientPassword());
         commands.put("unload patient", Back(previousController));
-        commands.put("back", Back(previousController));
 
         /* PENDING IMPLEMENTATION IN PHASE 2
         commands.put("view appointments", ViewAppointments());

--- a/src/controllers/SecretaryLoadedPatientController.java
+++ b/src/controllers/SecretaryLoadedPatientController.java
@@ -11,11 +11,10 @@ import java.util.LinkedHashMap;
 /**
  * Controller class that process the commands a secretary would use on a specific patient that they loaded.
  */
-public class SecretaryLoadedPatientController extends MenuController {
+public class SecretaryLoadedPatientController extends MenuLoadedPatientController {
 
     private final PatientData patientData;
     private final PatientManager patientManager;
-    private final SecretaryController previousController;
     private final SecretaryScreenView secretaryScreenView = new SecretaryScreenView();
 
     /* PHASE 2 ATTRIBUTES
@@ -35,7 +34,6 @@ public class SecretaryLoadedPatientController extends MenuController {
                                             PatientData patientData) {
         super(context, previousController);
         this.patientData = patientData;
-        this.previousController = previousController;
         this.patientManager = new PatientManager(getDatabase());
 
         /* PHASE 2 INSTANTIATIONS
@@ -55,7 +53,6 @@ public class SecretaryLoadedPatientController extends MenuController {
         LinkedHashMap<String, Command> commands = new LinkedHashMap<>();
         PrescriptionListCommands prescriptionListCommands = new PrescriptionListCommands(getDatabase(), patientData);
         commands.put("change patient password", ChangePatientPassword());
-        commands.put("unload patient", Back(previousController));
 
         /* PENDING IMPLEMENTATION IN PHASE 2
         commands.put("view appointments", ViewAppointments());

--- a/src/controllers/TerminalController.java
+++ b/src/controllers/TerminalController.java
@@ -137,10 +137,6 @@ abstract public class TerminalController {
         }
     }
 
-    protected Command Back(TerminalController previousController){
-        return (x) -> changeCurrentController(previousController);
-    }
-
     protected Command Exit() {
         return (x) -> exit();
     }

--- a/src/controllers/UserController.java
+++ b/src/controllers/UserController.java
@@ -27,7 +27,6 @@ public abstract class UserController<T extends User> extends TerminalController 
 
     /**
      * Creates a new controller for handling the state of when a user is signed in.
-     *
      * @param context Context - a reference to the context object, which stores the current controller and allows for
      *                       switching between controllers.
      * @param userData UserData<T> where T extends User - a data containing the ID and attributes of the current

--- a/test/AdminManagerTests.java
+++ b/test/AdminManagerTests.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertNull;
 public class AdminManagerTests {
     Database originalDatabase;
     DataMapperGateway<Admin> adminDatabase;
-    Admin admin;
+    AdminData adminData;
     AdminManager adminManager;
 
     /**
@@ -36,8 +36,8 @@ public class AdminManagerTests {
     public void before(){
         originalDatabase = new Database(databaseFolder.toString());
         adminDatabase = originalDatabase.getAdminDatabase();
-        admin = new Admin("jeff", "123", 123456789);
         adminManager = new AdminManager(originalDatabase);
+        adminData = adminManager.createAdmin("jeff", "123");
     }
 
     /**
@@ -46,24 +46,19 @@ public class AdminManagerTests {
      */
     @Test(timeout = 1000)
     public void testCreateAdminValid() {
-        String username = "jeff";
-        String password = "123";
-
-        AdminData adminData = adminManager.createAdmin(username, password);
-
         /* Testing if the return admin data is valid by testing if the fields of are equal to the parameters of
         createAdmin */
         assertEquals("The created admin data should have the same name as the parameters of " +
-                "createAdmin method", adminData.getUsername(), username);
+                "createAdmin method", adminData.getUsername(), "jeff");
 
         Admin loadedAdmin = adminDatabase.get(adminData.getId());
 
         /* Testing if the admin object has been correctly added to the database by testing if the fields of the loaded
         admin are equal to the parameters of createAdmin */
         assertEquals("Original admin and loaded admin should share the same unique username",
-                loadedAdmin.getUsername(), username);
+                loadedAdmin.getUsername(), "jeff");
         assertTrue("Original admin and loaded admin should share the same password",
-                loadedAdmin.comparePassword(password));
+                loadedAdmin.comparePassword("123"));
     }
 
     /**
@@ -71,13 +66,8 @@ public class AdminManagerTests {
      */
     @Test(timeout = 1000)
     public void testCreateAdminInvalid() {
-        String username = "jeff";
-        String password = "123";
-
-        adminManager.createAdmin(username, password);
-
         assertNull("creating a user with the same name and password already existing in the database " +
-                "should return null", adminManager.createAdmin(username, password));
+                "should return null", adminManager.createAdmin("jeff", "123"));
     }
 
     /**
@@ -86,15 +76,13 @@ public class AdminManagerTests {
      */
     @Test(timeout = 1000)
     public void testDeleteAdmin() {
-        Integer adminID = adminDatabase.add(admin);
-
         assertNotNull("An admin object should be returned before it is deleted ",
-                adminDatabase.get(adminID));
+                adminDatabase.get(adminData.getId()));
 
-        adminManager.deleteUser(admin.getUsername());
+        adminManager.deleteUser(adminData.getUsername());
 
         assertNull("An admin object should not be returned after it is deleted ",
-                adminDatabase.get(adminID));
+                adminDatabase.get(adminData.getId()));
     }
 
     /**
@@ -102,20 +90,16 @@ public class AdminManagerTests {
      */
     @Test(timeout = 1000)
     public void getUserData() {
-        adminDatabase.add(admin);
-
-        AdminData adminData = adminManager.getUserData(admin.getUsername());
+        AdminData loadedAdminData = adminManager.getUserData(adminData.getUsername());
 
         /* Testing if the adminData and the original admin are equal by testing whether all the fields of both
         objects are equal */
         assertEquals("admin and adminData should share the same Id",
-                admin.getId(), adminData.getId());
+                adminData.getId(), loadedAdminData.getId());
         assertEquals("admin and adminData should share the same unique username",
-                admin.getUsername(), adminData.getUsername());
+                adminData.getUsername(), loadedAdminData.getUsername());
         assertEquals("admin and adminData should share the same contact information",
-                admin.getContactInfoId(), adminData.getContactInfoId());
-        assertTrue("admin and adminData should share the same password",
-                admin.comparePassword("123"));
+                adminData.getContactInfoId(), loadedAdminData.getContactInfoId());
     }
 
     /**
@@ -133,16 +117,13 @@ public class AdminManagerTests {
      */
     @Test(timeout = 1000)
     public void testDeleteAdminByData() {
-        Integer adminID = adminDatabase.add(admin);
-        AdminData userdata = adminManager.getUserData(admin.getUsername());
-
         assertNotNull("An admin object should be returned before it is deleted",
-                adminDatabase.get(adminID));
+                adminDatabase.get(adminData.getId()));
 
-        adminManager.deleteUserByData(userdata);
+        adminManager.deleteUserByData(adminData);
 
         assertNull("An admin object should not be returned after it is deleted by data",
-                adminDatabase.get(adminID));
+                adminDatabase.get(adminData.getId()));
     }
 
     /**
@@ -151,17 +132,14 @@ public class AdminManagerTests {
      */
     @Test(timeout = 1000)
     public void testChangeUserPassword() {
-        Integer adminID = adminDatabase.add(admin);
-        AdminData adminData = new AdminData(admin);
-
         assertTrue("The password should remain the same before the change",
-                adminDatabase.get(adminID).comparePassword("123"));
+                adminDatabase.get(adminData.getId()).comparePassword("123"));
 
         adminManager.changeUserPassword(adminData, "456");
 
         assertTrue("The admin object should have the same password as we inputted into the parameters " +
                         "of the changeUserPassword method ",
-                adminDatabase.get(adminID).comparePassword("456"));
+                adminDatabase.get(adminData.getId()).comparePassword("456"));
     }
 
     /**
@@ -170,21 +148,15 @@ public class AdminManagerTests {
      */
     @Test(timeout = 1000)
     public void testGetAdmin() {
-        Admin originalAdmin = admin;
-        Integer adminID = adminDatabase.add(originalAdmin);
-
-        assertEquals("Original admin should share the same ID from the database",
-                originalAdmin.getId(), adminID);
-
-        Admin loadedAdmin = adminDatabase.get(originalAdmin.getId());
+        Admin loadedAdmin = adminDatabase.get(adminData.getId());
         /* Testing if the loaded admin and the original admin are equal by testing whether all the fields of both
         objects are equal */
         assertEquals("Original admin and loaded admin should share the same Id",
-                originalAdmin.getId(), loadedAdmin.getId());
+                adminData.getId(), loadedAdmin.getId());
         assertEquals("Original admin and loaded admin should share the same unique username",
-                originalAdmin.getUsername(), loadedAdmin.getUsername());
+                adminData.getUsername(), loadedAdmin.getUsername());
         assertEquals("Original admin and loaded admin should share the same contact information",
-                originalAdmin.getContactInfoId(), loadedAdmin.getContactInfoId());
+                adminData.getContactInfoId(), loadedAdmin.getContactInfoId());
         assertTrue("Original admin and loaded admin should share the same password",
                 loadedAdmin.comparePassword("123"));
     }
@@ -194,12 +166,10 @@ public class AdminManagerTests {
      */
     @Test(timeout = 1000)
     public void testDoesUserExist(){
-        Integer adminId = adminDatabase.add(admin);
-
         assertNotNull("An admin object should be returned when added to the database",
-                adminDatabase.get(adminId));
+                adminDatabase.get(adminData.getId()));
         assertTrue("DoesUserExist should return true since the admin is stored in the database",
-                adminManager.doesUserExist(admin.getUsername()));
+                adminManager.doesUserExist(adminData.getUsername()));
     }
 
     /**
@@ -217,8 +187,6 @@ public class AdminManagerTests {
      */
     @Test(timeout = 1000)
     public void testCanSignInValid(){
-        adminDatabase.add(admin);
-
         assertTrue("canSignIn should return true if given a username and password to an account in the " +
                 "database", adminManager.canSignIn("jeff", "123"));
     }
@@ -229,8 +197,6 @@ public class AdminManagerTests {
      */
     @Test(timeout = 1000)
     public void testCanSignInInvalid(){
-        adminDatabase.add(admin);
-
         assertFalse("canSignIn should return false if given a username and password not linked to an account" +
                 "in the database", adminManager.canSignIn("jim", "password"));
     }
@@ -240,11 +206,8 @@ public class AdminManagerTests {
      */
     @Test(timeout = 1000)
     public void testSignInExistingAccount(){
-        adminDatabase.add(admin);
-        AdminData adminData = adminManager.getUserData(admin.getUsername());
-
         assertEquals("A correct account detail sign in should return the respective adminData",
-                adminManager.signIn(admin.getUsername(), "123").getId(), adminData.getId());
+                adminManager.signIn(adminData.getUsername(), "123").getId(), adminData.getId());
     }
 
     /**
@@ -253,8 +216,6 @@ public class AdminManagerTests {
      */
     @Test(timeout = 1000)
     public void testSignInNonExistingAccount(){
-        adminDatabase.add(admin);
-
         assertNull("an incorrect account detail sign in should return null", adminManager.signIn("jim",
                 "password"));
     }

--- a/test/AdminManagerTests.java
+++ b/test/AdminManagerTests.java
@@ -17,10 +17,6 @@ import static org.junit.Assert.assertNull;
  * Class of unit tests for AdminManager use case class.
  */
 public class AdminManagerTests {
-    Database originalDatabase;
-    DataMapperGateway<Admin> adminDatabase;
-    AdminData adminData;
-    AdminManager adminManager;
 
     /**
      * The variable representing the temporary folder where the databases used in these tests are stored until it is
@@ -28,13 +24,16 @@ public class AdminManagerTests {
      */
     @Rule
     public TemporaryFolder databaseFolder = new TemporaryFolder();
+    private DataMapperGateway<Admin> adminDatabase;
+    private AdminData adminData;
+    private AdminManager adminManager;
 
     /**
      * Initializes the variables used by all the tests before each unit test.
      */
     @Before
     public void before(){
-        originalDatabase = new Database(databaseFolder.toString());
+        Database originalDatabase = new Database(databaseFolder.toString());
         adminDatabase = originalDatabase.getAdminDatabase();
         adminManager = new AdminManager(originalDatabase);
         adminData = adminManager.createAdmin("jeff", "123");

--- a/test/AdminManagerTests.java
+++ b/test/AdminManagerTests.java
@@ -12,11 +12,18 @@ import java.io.File;
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertNull;
 
+/**
+ * A class that tests AdminManager.
+ */
 public class AdminManagerTests {
 
     @Rule
     public TemporaryFolder databaseFolder = new TemporaryFolder();
 
+    /**
+     * Tests createAdmin by creating an admin in the database, and that admin with the adminData to ensure they
+     * represent the same entity.
+     */
     @Test(timeout = 1000)
     public void testCreateAdminValid() {
         Database originalDatabase = new Database(databaseFolder.toString());
@@ -42,6 +49,10 @@ public class AdminManagerTests {
         assertTrue("Original admin and loaded admin should share the same password",
                 loadedAdmin.comparePassword(password));
     }
+
+    /**
+     * Test invalid createAdmin with a username that already exists in the database.
+     */
     @Test(timeout = 1000)
     public void testCreateAdminInvalid() {
         Database originalDatabase = new Database(databaseFolder.toString());
@@ -56,6 +67,10 @@ public class AdminManagerTests {
                 "should return null", adminManager.createAdmin(username, password));
     }
 
+    /**
+     * Test deleteAdmin by ensuring an admin exists in the database, deleting it, then ensuring that the admin cannot
+     * be access by using its adminID.
+     */
     @Test(timeout = 1000)
     public void testDeleteAdmin() {
         Database originalDatabase = new Database(databaseFolder.toString());
@@ -76,6 +91,10 @@ public class AdminManagerTests {
         assertNull("An admin object should not be returned after it is deleted ",
                 adminDatabase.get(adminID));
     }
+
+    /**
+     * Testing getUserData by ensuring that the data entity values match up with the values stored in the database.
+     */
     @Test(timeout = 1000)
     public void getUserData() {
         Database originalDatabase = new Database(databaseFolder.toString());
@@ -101,6 +120,10 @@ public class AdminManagerTests {
         assertTrue("admin and adminData should share the same password",
                 admin.comparePassword("123"));
     }
+
+    /**
+     * Tests an invalid use of getUserData by getting a user that does not exist.
+     */
     @Test(timeout = 1000)
     public void getUserDataInvalid() {
         Database originalDatabase = new Database(databaseFolder.toString());
@@ -110,6 +133,11 @@ public class AdminManagerTests {
                 adminManager.getUserData("jim"));
 
     }
+
+    /**
+     * Test deleteUserByData specifically with an Admin account, ensuring that the admin cannot be access by using
+     * its adminID.
+     */
     @Test(timeout = 1000)
     public void testDeleteAdminByData() {
         Database originalDatabase = new Database(databaseFolder.toString());
@@ -132,6 +160,10 @@ public class AdminManagerTests {
                 adminDatabase.get(adminID));
     }
 
+    /**
+     * Tests changeUserPassword for admin accounts, by comparing the password in the database before and after the
+     * change.
+     */
     @Test(timeout = 1000)
     public void testChangeUserPassword() {
         Database originalDatabase = new Database(databaseFolder.toString());
@@ -155,6 +187,10 @@ public class AdminManagerTests {
                 adminDatabase.get(adminID).comparePassword("456"));
     }
 
+    /**
+     * Tests getAdmin by comparing the values of the entity and the values stored under the admin in the database to
+     * ensure that they represent the same entity.
+     */
     @Test(timeout = 1000)
     public void testGetAdmin() {
         Database originalDatabase = new Database(databaseFolder.toString());
@@ -181,6 +217,9 @@ public class AdminManagerTests {
                 loadedAdmin.comparePassword("123"));
     }
 
+    /**
+     * Tests doesUserExist by ensuring an admin exists in the database, then testing if the bool returned is true.
+     */
     @Test(timeout = 1000)
     public void testDoesUserExist(){
         Database originalDatabase = new Database(databaseFolder.toString());
@@ -197,6 +236,9 @@ public class AdminManagerTests {
         assertTrue("DoesUserExist should return true since the admin is stored in the database",
                 adminManager.doesUserExist(admin.getUsername()));
     }
+    /**
+     * Tests doesUserExist by ensuring an admin exists in the database, then testing if the bool returned is false.
+     */
     @Test(timeout = 1000)
     public void testUserDoesNotExist(){
         Database originalDatabase = new Database(databaseFolder.toString());
@@ -207,6 +249,11 @@ public class AdminManagerTests {
                         "inputted username",
                 adminManager.doesUserExist("jim"));
     }
+
+    /**
+     * Tests canSignIn by ensuring that if a username and password is linked to an account in the database, a true
+     * boolean should be returned.
+     */
     @Test(timeout = 1000)
     public void testCanSignInValid(){
         Database originalDatabase = new Database(databaseFolder.toString());
@@ -221,6 +268,10 @@ public class AdminManagerTests {
         assertTrue("canSignIn should return true if given a username and password to an account in the " +
                 "database", adminManager.canSignIn("jeff", "123"));
     }
+    /**
+     * Tests canSignIn by ensuring that if a username and password is not linked to an account in the database, a false
+     * boolean should be returned.
+     */
     @Test(timeout = 1000)
     public void testCanSignInInvalid(){
         Database originalDatabase = new Database(databaseFolder.toString());
@@ -235,6 +286,10 @@ public class AdminManagerTests {
         assertFalse("canSignIn should return false if given a username and password not linked to an account" +
                 "in the database", adminManager.canSignIn("jim", "password"));
     }
+
+    /**
+     * Tests a valid use of the signIn function with an existing account.
+     */
     @Test(timeout = 1000)
     public void testSignInExistingAccount(){
         Database originalDatabase = new Database(databaseFolder.toString());
@@ -251,6 +306,10 @@ public class AdminManagerTests {
                 adminManager.signIn(admin.getUsername(), "123").getId(), adminData.getId());
     }
 
+    /**
+     * Tests the signIn function when invalid account username or password is inputted, not matching with an account
+     * in the database.
+     */
     @Test(timeout = 1000)
     public void testSignInNonExistingAccount(){
         Database originalDatabase = new Database(databaseFolder.toString());

--- a/test/AdminManagerTests.java
+++ b/test/AdminManagerTests.java
@@ -75,9 +75,15 @@ public class AdminManagerTests {
      */
     @Test(timeout = 1000)
     public void testCreateAdminInvalidFormat() {
-        assertThrows("creating a user with a non-alphanumeric username and a password shorter than 8 " +
-                        "characters will return an illegal argument exception", IllegalArgumentException.class,
-                () -> adminManager.createAdmin("!!!", "123"));
+        assertThrows("creating a user with a non-alphanumeric username characters will return an illegal " +
+                        "argument exception", IllegalArgumentException.class,
+                () -> adminManager.createAdmin("newuser!", "123456789"));
+        assertThrows("creating a user with a username shorter than 6 characters will return an illegal " +
+                        "argument exception", IllegalArgumentException.class,
+                () -> adminManager.createAdmin("newu", "123456789"));
+        assertThrows("creating a user with a password shorter than 8 characters will return an illegal " +
+                        "argument exception", IllegalArgumentException.class,
+                () -> adminManager.createAdmin("newuser1", "1234567"));
     }
 
     /**

--- a/test/AdminManagerTests.java
+++ b/test/AdminManagerTests.java
@@ -14,7 +14,7 @@ import static org.junit.Assert.*;
 import static org.junit.Assert.assertNull;
 
 /**
- * A class that tests AdminManager.
+ * Class of unit tests for AdminManager use case class.
  */
 public class AdminManagerTests {
     Database originalDatabase;

--- a/test/AdminManagerTests.java
+++ b/test/AdminManagerTests.java
@@ -42,11 +42,10 @@ public class AdminManagerTests {
     }
 
     /**
-     * Tests createAdmin by creating an admin in the database, and that admin with the adminData to ensure they
-     * represent the same entity.
+     * Tests createAdmin by creating an admin in the database using a valid and unused username.
      */
     @Test(timeout = 1000)
-    public void testCreateAdminValid() {
+    public void testCreateAdminValidNonExistent() {
         /* Testing if the return admin data is valid by testing if the fields of are equal to the parameters of
         createAdmin */
         assertEquals("The created admin data should have the same name as the parameters of " +
@@ -62,13 +61,23 @@ public class AdminManagerTests {
                 loadedAdmin.comparePassword(password));
     }
 
-    /**
-     * Test invalid createAdmin with a username that already exists in the database.
-     */
+     /**
+      * Tests createAdmin with a username that already exists in the database.
+      */
     @Test(timeout = 1000)
-    public void testCreateAdminInvalid() {
+    public void testCreateAdminExistingUsername() {
         assertNull("creating a user with the same name and password already existing in the database " +
                 "should return null", adminManager.createAdmin(username, password));
+    }
+
+    /**
+     * Tests createAdmin with a format that does pass the regex check.
+     */
+    @Test(timeout = 1000)
+    public void testCreateAdminInvalidFormat() {
+        assertThrows("creating a user with a non-alphanumeric username and a password shorter than 8 " +
+                        "characters will return an illegal argument exception", IllegalArgumentException.class,
+                () -> adminManager.createAdmin("!!!", "123"));
     }
 
     /**

--- a/test/AdminManagerTests.java
+++ b/test/AdminManagerTests.java
@@ -22,9 +22,16 @@ public class AdminManagerTests {
     Admin admin;
     AdminManager adminManager;
 
+    /**
+     * The variable representing the temporary folder where the databases used in these tests are stored until it is
+     * deleted after the tests.
+     */
     @Rule
     public TemporaryFolder databaseFolder = new TemporaryFolder();
 
+    /**
+     * Initializes the variables used by all the tests before each unit test.
+     */
     @Before
     public void before(){
         originalDatabase = new Database(databaseFolder.toString());
@@ -251,6 +258,10 @@ public class AdminManagerTests {
         assertNull("an incorrect account detail sign in should return null", adminManager.signIn("jim",
                 "password"));
     }
+
+    /**
+     * Deletes the temporary database folder used to store the database for tests after tests are done.
+     */
     @After
     public void after() {
         DeleteUtils.deleteDirectory(new File(databaseFolder.toString()));

--- a/test/AdminManagerTests.java
+++ b/test/AdminManagerTests.java
@@ -27,6 +27,8 @@ public class AdminManagerTests {
     private DataMapperGateway<Admin> adminDatabase;
     private AdminData adminData;
     private AdminManager adminManager;
+    private final String username = "mynamejeff";
+    private final String password = "123456789";
 
     /**
      * Initializes the variables used by all the tests before each unit test.
@@ -36,7 +38,7 @@ public class AdminManagerTests {
         Database originalDatabase = new Database(databaseFolder.toString());
         adminDatabase = originalDatabase.getAdminDatabase();
         adminManager = new AdminManager(originalDatabase);
-        adminData = adminManager.createAdmin("jeff", "123");
+        adminData = adminManager.createAdmin(username, password);
     }
 
     /**
@@ -48,16 +50,16 @@ public class AdminManagerTests {
         /* Testing if the return admin data is valid by testing if the fields of are equal to the parameters of
         createAdmin */
         assertEquals("The created admin data should have the same name as the parameters of " +
-                "createAdmin method", adminData.getUsername(), "jeff");
+                "createAdmin method", adminData.getUsername(), username);
 
         Admin loadedAdmin = adminDatabase.get(adminData.getId());
 
         /* Testing if the admin object has been correctly added to the database by testing if the fields of the loaded
         admin are equal to the parameters of createAdmin */
         assertEquals("Original admin and loaded admin should share the same unique username",
-                loadedAdmin.getUsername(), "jeff");
+                loadedAdmin.getUsername(), username);
         assertTrue("Original admin and loaded admin should share the same password",
-                loadedAdmin.comparePassword("123"));
+                loadedAdmin.comparePassword(password));
     }
 
     /**
@@ -66,7 +68,7 @@ public class AdminManagerTests {
     @Test(timeout = 1000)
     public void testCreateAdminInvalid() {
         assertNull("creating a user with the same name and password already existing in the database " +
-                "should return null", adminManager.createAdmin("jeff", "123"));
+                "should return null", adminManager.createAdmin(username, password));
     }
 
     /**
@@ -107,7 +109,7 @@ public class AdminManagerTests {
     @Test(timeout = 1000)
     public void getUserDataInvalid() {
         assertNull("trying to get user data of a user that doesn't exist should return null",
-                adminManager.getUserData("jim"));
+                adminManager.getUserData("jimhalpert"));
     }
 
     /**
@@ -132,7 +134,7 @@ public class AdminManagerTests {
     @Test(timeout = 1000)
     public void testChangeUserPassword() {
         assertTrue("The password should remain the same before the change",
-                adminDatabase.get(adminData.getId()).comparePassword("123"));
+                adminDatabase.get(adminData.getId()).comparePassword(password));
 
         adminManager.changeUserPassword(adminData, "456");
 
@@ -157,7 +159,7 @@ public class AdminManagerTests {
         assertEquals("Original admin and loaded admin should share the same contact information",
                 adminData.getContactInfoId(), loadedAdmin.getContactInfoId());
         assertTrue("Original admin and loaded admin should share the same password",
-                loadedAdmin.comparePassword("123"));
+                loadedAdmin.comparePassword(password));
     }
 
     /**
@@ -177,7 +179,7 @@ public class AdminManagerTests {
     @Test(timeout = 1000)
     public void testUserDoesNotExist(){
         assertFalse("DoesUserExist should return false if there is no account stored in the database with the" +
-                        "inputted username", adminManager.doesUserExist("jim"));
+                        "inputted username", adminManager.doesUserExist("jimhalpert"));
     }
 
     /**
@@ -187,7 +189,7 @@ public class AdminManagerTests {
     @Test(timeout = 1000)
     public void testCanSignInValid(){
         assertTrue("canSignIn should return true if given a username and password to an account in the " +
-                "database", adminManager.canSignIn("jeff", "123"));
+                "database", adminManager.canSignIn(username, password));
     }
 
     /**
@@ -197,7 +199,7 @@ public class AdminManagerTests {
     @Test(timeout = 1000)
     public void testCanSignInInvalid(){
         assertFalse("canSignIn should return false if given a username and password not linked to an account" +
-                "in the database", adminManager.canSignIn("jim", "password"));
+                "in the database", adminManager.canSignIn("jimhalpert", "password"));
     }
 
     /**
@@ -206,7 +208,7 @@ public class AdminManagerTests {
     @Test(timeout = 1000)
     public void testSignInExistingAccount(){
         assertEquals("A correct account detail sign in should return the respective adminData",
-                adminManager.signIn(adminData.getUsername(), "123").getId(), adminData.getId());
+                adminManager.signIn(adminData.getUsername(), password).getId(), adminData.getId());
     }
 
     /**
@@ -215,8 +217,8 @@ public class AdminManagerTests {
      */
     @Test(timeout = 1000)
     public void testSignInNonExistingAccount(){
-        assertNull("an incorrect account detail sign in should return null", adminManager.signIn("jim",
-                "password"));
+        assertNull("an incorrect account detail sign in should return null", adminManager.signIn(
+                "jimhalpert", "password"));
     }
 
     /**

--- a/test/AdminManagerTests.java
+++ b/test/AdminManagerTests.java
@@ -3,6 +3,7 @@ import database.DataMapperGateway;
 import database.Database;
 import entities.Admin;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -16,9 +17,21 @@ import static org.junit.Assert.assertNull;
  * A class that tests AdminManager.
  */
 public class AdminManagerTests {
+    Database originalDatabase;
+    DataMapperGateway<Admin> adminDatabase;
+    Admin admin;
+    AdminManager adminManager;
 
     @Rule
     public TemporaryFolder databaseFolder = new TemporaryFolder();
+
+    @Before
+    public void before(){
+        originalDatabase = new Database(databaseFolder.toString());
+        adminDatabase = originalDatabase.getAdminDatabase();
+        admin = new Admin("jeff", "123", 123456789);
+        adminManager = new AdminManager(originalDatabase);
+    }
 
     /**
      * Tests createAdmin by creating an admin in the database, and that admin with the adminData to ensure they
@@ -26,12 +39,8 @@ public class AdminManagerTests {
      */
     @Test(timeout = 1000)
     public void testCreateAdminValid() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Admin> adminDatabase = originalDatabase.getAdminDatabase();
-
         String username = "jeff";
         String password = "123";
-        AdminManager adminManager = new AdminManager(originalDatabase);
 
         AdminData adminData = adminManager.createAdmin(username, password);
 
@@ -55,11 +64,8 @@ public class AdminManagerTests {
      */
     @Test(timeout = 1000)
     public void testCreateAdminInvalid() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-
         String username = "jeff";
         String password = "123";
-        AdminManager adminManager = new AdminManager(originalDatabase);
 
         adminManager.createAdmin(username, password);
 
@@ -73,14 +79,6 @@ public class AdminManagerTests {
      */
     @Test(timeout = 1000)
     public void testDeleteAdmin() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Admin> adminDatabase = originalDatabase.getAdminDatabase();
-
-        Admin admin = new
-                Admin("jeff", "123", 123456789);
-
-        AdminManager adminManager = new AdminManager(originalDatabase);
-
         Integer adminID = adminDatabase.add(admin);
 
         assertNotNull("An admin object should be returned before it is deleted ",
@@ -97,14 +95,6 @@ public class AdminManagerTests {
      */
     @Test(timeout = 1000)
     public void getUserData() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Admin> adminDatabase = originalDatabase.getAdminDatabase();
-
-        Admin admin = new
-                Admin("jeff", "123", 123456789);
-
-        AdminManager adminManager = new AdminManager(originalDatabase);
-
         adminDatabase.add(admin);
 
         AdminData adminData = adminManager.getUserData(admin.getUsername());
@@ -126,12 +116,8 @@ public class AdminManagerTests {
      */
     @Test(timeout = 1000)
     public void getUserDataInvalid() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        AdminManager adminManager = new AdminManager(originalDatabase);
-
         assertNull("trying to get user data of a user that doesn't exist should return null",
                 adminManager.getUserData("jim"));
-
     }
 
     /**
@@ -140,14 +126,6 @@ public class AdminManagerTests {
      */
     @Test(timeout = 1000)
     public void testDeleteAdminByData() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Admin> adminDatabase = originalDatabase.getAdminDatabase();
-
-        Admin admin = new
-                Admin("jeff", "123", 123456789);
-
-        AdminManager adminManager = new AdminManager(originalDatabase);
-
         Integer adminID = adminDatabase.add(admin);
         AdminData userdata = adminManager.getUserData(admin.getUsername());
 
@@ -166,14 +144,6 @@ public class AdminManagerTests {
      */
     @Test(timeout = 1000)
     public void testChangeUserPassword() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Admin> adminDatabase = originalDatabase.getAdminDatabase();
-
-        Admin admin = new
-                Admin("jeff", "123", 123456789);
-
-        AdminManager adminManager = new AdminManager(originalDatabase);
-
         Integer adminID = adminDatabase.add(admin);
         AdminData adminData = new AdminData(admin);
 
@@ -193,12 +163,7 @@ public class AdminManagerTests {
      */
     @Test(timeout = 1000)
     public void testGetAdmin() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Admin> adminDatabase = originalDatabase.getAdminDatabase();
-
-        Admin originalAdmin = new
-                Admin("jeff", "123", 123456789);
-
+        Admin originalAdmin = admin;
         Integer adminID = adminDatabase.add(originalAdmin);
 
         assertEquals("Original admin should share the same ID from the database",
@@ -222,13 +187,6 @@ public class AdminManagerTests {
      */
     @Test(timeout = 1000)
     public void testDoesUserExist(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Admin> adminDatabase = originalDatabase.getAdminDatabase();
-
-        Admin admin = new
-                Admin("jeff", "123", 123456789);
-
-        AdminManager adminManager = new AdminManager(originalDatabase);
         Integer adminId = adminDatabase.add(admin);
 
         assertNotNull("An admin object should be returned when added to the database",
@@ -236,18 +194,14 @@ public class AdminManagerTests {
         assertTrue("DoesUserExist should return true since the admin is stored in the database",
                 adminManager.doesUserExist(admin.getUsername()));
     }
+
     /**
      * Tests doesUserExist by ensuring an admin exists in the database, then testing if the bool returned is false.
      */
     @Test(timeout = 1000)
     public void testUserDoesNotExist(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-
-        AdminManager adminManager = new AdminManager(originalDatabase);
-
         assertFalse("DoesUserExist should return false if there is no account stored in the database with the" +
-                        "inputted username",
-                adminManager.doesUserExist("jim"));
+                        "inputted username", adminManager.doesUserExist("jim"));
     }
 
     /**
@@ -256,31 +210,18 @@ public class AdminManagerTests {
      */
     @Test(timeout = 1000)
     public void testCanSignInValid(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Admin> adminDatabase = originalDatabase.getAdminDatabase();
-
-        Admin admin = new
-                Admin("jeff", "123", 123456789);
-
-        AdminManager adminManager = new AdminManager(originalDatabase);
         adminDatabase.add(admin);
 
         assertTrue("canSignIn should return true if given a username and password to an account in the " +
                 "database", adminManager.canSignIn("jeff", "123"));
     }
+
     /**
      * Tests canSignIn by ensuring that if a username and password is not linked to an account in the database, a false
      * boolean should be returned.
      */
     @Test(timeout = 1000)
     public void testCanSignInInvalid(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Admin> adminDatabase = originalDatabase.getAdminDatabase();
-
-        Admin admin = new
-                Admin("jeff", "123", 123456789);
-
-        AdminManager adminManager = new AdminManager(originalDatabase);
         adminDatabase.add(admin);
 
         assertFalse("canSignIn should return false if given a username and password not linked to an account" +
@@ -292,13 +233,6 @@ public class AdminManagerTests {
      */
     @Test(timeout = 1000)
     public void testSignInExistingAccount(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Admin> adminDatabase = originalDatabase.getAdminDatabase();
-
-        Admin admin = new
-                Admin("jeff", "123", 123456789);
-
-        AdminManager adminManager = new AdminManager(originalDatabase);
         adminDatabase.add(admin);
         AdminData adminData = adminManager.getUserData(admin.getUsername());
 
@@ -312,13 +246,6 @@ public class AdminManagerTests {
      */
     @Test(timeout = 1000)
     public void testSignInNonExistingAccount(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Admin> adminDatabase = originalDatabase.getAdminDatabase();
-
-        Admin admin = new
-                Admin("jeff", "123", 123456789);
-
-        AdminManager adminManager = new AdminManager(originalDatabase);
         adminDatabase.add(admin);
 
         assertNull("an incorrect account detail sign in should return null", adminManager.signIn("jim",

--- a/test/AdminManagerTests.java
+++ b/test/AdminManagerTests.java
@@ -1,5 +1,4 @@
 import dataBundles.AdminData;
-import dataBundles.ContactData;
 import database.DataMapperGateway;
 import database.Database;
 import entities.Admin;
@@ -10,7 +9,6 @@ import org.junit.rules.TemporaryFolder;
 import useCases.AdminManager;
 import utilities.DeleteUtils;
 import java.io.File;
-import java.time.LocalDate;
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertNull;
 
@@ -26,12 +24,6 @@ public class AdminManagerTests {
 
         String username = "jeff";
         String password = "123";
-        LocalDate birthday = LocalDate.of(2022, 1, 1);
-        ContactData contactData = new ContactData("jeff", "jeff@gmail.com",
-                "12345678", "jeff street", birthday, "jim",
-                "jim@gmail.com", "87654321",
-                "father");
-
         AdminManager adminManager = new AdminManager(originalDatabase);
 
         AdminData adminData = adminManager.createAdmin(username, password);
@@ -53,19 +45,12 @@ public class AdminManagerTests {
     @Test(timeout = 1000)
     public void testCreateAdminInvalid() {
         Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Admin> adminDatabase = originalDatabase.getAdminDatabase();
 
         String username = "jeff";
         String password = "123";
-        LocalDate birthday = LocalDate.of(2022, 1, 1);
-        ContactData contactData = new ContactData("jeff", "jeff@gmail.com",
-                "12345678", "jeff street", birthday, "jim",
-                "jim@gmail.com", "87654321",
-                "father");
-
         AdminManager adminManager = new AdminManager(originalDatabase);
 
-        AdminData adminData = adminManager.createAdmin(username, password);
+        adminManager.createAdmin(username, password);
 
         assertNull("creating a user with the same name and password already existing in the database " +
                 "should return null", adminManager.createAdmin(username, password));
@@ -101,7 +86,7 @@ public class AdminManagerTests {
 
         AdminManager adminManager = new AdminManager(originalDatabase);
 
-        Integer adminID = adminDatabase.add(admin);
+        adminDatabase.add(admin);
 
         AdminData adminData = adminManager.getUserData(admin.getUsername());
 
@@ -138,7 +123,7 @@ public class AdminManagerTests {
         Integer adminID = adminDatabase.add(admin);
         AdminData userdata = adminManager.getUserData(admin.getUsername());
 
-        assertNotNull("An admin object should be returned before it is deleted ",
+        assertNotNull("An admin object should be returned before it is deleted",
                 adminDatabase.get(adminID));
 
         adminManager.deleteUserByData(userdata);
@@ -160,7 +145,7 @@ public class AdminManagerTests {
         Integer adminID = adminDatabase.add(admin);
         AdminData adminData = new AdminData(admin);
 
-        assertTrue("The password should remain the same before the change ",
+        assertTrue("The password should remain the same before the change",
                 adminDatabase.get(adminID).comparePassword("123"));
 
         adminManager.changeUserPassword(adminData, "456");
@@ -177,8 +162,6 @@ public class AdminManagerTests {
 
         Admin originalAdmin = new
                 Admin("jeff", "123", 123456789);
-
-        AdminManager adminManager = new AdminManager(originalDatabase);
 
         Integer adminID = adminDatabase.add(originalAdmin);
 
@@ -217,13 +200,8 @@ public class AdminManagerTests {
     @Test(timeout = 1000)
     public void testUserDoesNotExist(){
         Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Admin> adminDatabase = originalDatabase.getAdminDatabase();
-
-        Admin admin = new
-                Admin("jeff", "123", 123456789);
 
         AdminManager adminManager = new AdminManager(originalDatabase);
-        Integer adminId = adminDatabase.add(admin);
 
         assertFalse("DoesUserExist should return false if there is no account stored in the database with the" +
                         "inputted username",
@@ -238,7 +216,7 @@ public class AdminManagerTests {
                 Admin("jeff", "123", 123456789);
 
         AdminManager adminManager = new AdminManager(originalDatabase);
-        Integer adminId = adminDatabase.add(admin);
+        adminDatabase.add(admin);
 
         assertTrue("canSignIn should return true if given a username and password to an account in the " +
                 "database", adminManager.canSignIn("jeff", "123"));
@@ -252,7 +230,7 @@ public class AdminManagerTests {
                 Admin("jeff", "123", 123456789);
 
         AdminManager adminManager = new AdminManager(originalDatabase);
-        Integer adminId = adminDatabase.add(admin);
+        adminDatabase.add(admin);
 
         assertFalse("canSignIn should return false if given a username and password not linked to an account" +
                 "in the database", adminManager.canSignIn("jim", "password"));
@@ -266,7 +244,7 @@ public class AdminManagerTests {
                 Admin("jeff", "123", 123456789);
 
         AdminManager adminManager = new AdminManager(originalDatabase);
-        Integer adminId = adminDatabase.add(admin);
+        adminDatabase.add(admin);
         AdminData adminData = adminManager.getUserData(admin.getUsername());
 
         assertEquals("A correct account detail sign in should return the respective adminData",
@@ -282,8 +260,7 @@ public class AdminManagerTests {
                 Admin("jeff", "123", 123456789);
 
         AdminManager adminManager = new AdminManager(originalDatabase);
-        Integer adminId = adminDatabase.add(admin);
-        AdminData adminData = adminManager.getUserData(admin.getUsername());
+        adminDatabase.add(admin);
 
         assertNull("an incorrect account detail sign in should return null", adminManager.signIn("jim",
                 "password"));
@@ -292,4 +269,5 @@ public class AdminManagerTests {
     public void after() {
         DeleteUtils.deleteDirectory(new File(databaseFolder.toString()));
     }
+
 }

--- a/test/AppointmentManagerTests.java
+++ b/test/AppointmentManagerTests.java
@@ -33,8 +33,10 @@ public class AppointmentManagerTests {
                 new ArrayList<>(List.of(new Availability(DayOfWeek.of(1), LocalTime.of(8, 30),
                         LocalTime.of(17, 0))))));
 
-        DoctorData doctorData = new DoctorManager(originalDatabase).createDoctor("test1", "test1");
-        PatientData patientData = new PatientManager(originalDatabase).createPatient("test2", "test2");
+        DoctorData doctorData = new DoctorManager(originalDatabase).createDoctor("testdoctor",
+                "123456789");
+        PatientData patientData = new PatientManager(originalDatabase).createPatient("testpatient",
+                "123456789");
 
         assertTrue("An appointment object should not exist in the database before booking one",
                 originalDatabase.getAppointmentDatabase().getAllIds().isEmpty());
@@ -163,8 +165,10 @@ public class AppointmentManagerTests {
                 new ArrayList<>(List.of(new Availability(DayOfWeek.of(1), LocalTime.of(8, 30),
                         LocalTime.of(17, 0))))));
 
-        DoctorData doctorData = new DoctorManager(originalDatabase).createDoctor("test1", "test1");
-        PatientData patientData = new PatientManager(originalDatabase).createPatient("test2", "test2");
+        DoctorData doctorData = new DoctorManager(originalDatabase).createDoctor("testdoctor",
+                "123456789");
+        PatientData patientData = new PatientManager(originalDatabase).createPatient("testpatient",
+                "123456789");
         AppointmentData appointment = new AppointmentManager(originalDatabase).bookAppointment(patientData, doctorData,
                 2022, 12, 1, 10, 0, 120);
 

--- a/test/ClinicManagerTests.java
+++ b/test/ClinicManagerTests.java
@@ -18,6 +18,9 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * Class of unit tests for ClinicManager use case class.
+ */
 public class ClinicManagerTests {
 
     /**

--- a/test/ClinicManagerTests.java
+++ b/test/ClinicManagerTests.java
@@ -30,23 +30,23 @@ public class ClinicManagerTests {
     private Clinic clinic;
 
     /**
-     * Initializes the variable before each unit test.
+     * Initializes the variables used by all the tests before each unit test.
      */
     @Before
     public void before() {
         Database originalDatabase = new Database(databaseFolder.toString());
-        clinicManager = new ClinicManager(originalDatabase);
         clinic = new Clinic("ABC", "4169782011", "abc@gmail.com", "address",
                 new ArrayList<>(List.of(new Availability(DayOfWeek.of(1), LocalTime.of(8, 30),
                         LocalTime.of(17, 0)))));
         originalDatabase.setClinic(clinic);
+        clinicManager = new ClinicManager(originalDatabase);
     }
 
     /**
      * Tests the clinic manager method that changes the clinic's phone number with an input that fails the regex check.
      */
     @Test(timeout = 1000)
-    public void changeClinicPhoneNumberFailsRegex(){
+    public void changeClinicPhoneNumberFailsRegex() {
         assertEquals("The clinic phone should stay same before changing it.",
                clinic.getPhoneNumber(), "4169782011");
 
@@ -60,7 +60,7 @@ public class ClinicManagerTests {
      * Tests the clinic manager method that changes the clinic's phone number with an input that passes the regex check.
      */
     @Test(timeout = 1000)
-    public void changeClinicPhoneNumberPassesRegex(){
+    public void changeClinicPhoneNumberPassesRegex() {
         assertEquals("The clinic phone should stay same before changing it.",
                 clinic.getPhoneNumber(), "4169782011");
 
@@ -116,7 +116,7 @@ public class ClinicManagerTests {
      * Tests the clinic manager method that changes the clinic's email with an input that passes the regex check.
      */
     @Test(timeout = 1000)
-    public void changeClinicEmailAddressPassesRegex(){
+    public void changeClinicEmailAddressPassesRegex() {
         assertEquals("The clinic address should stay same before changing it.",
                 clinic.getEmail(), "abc@gmail.com");
 

--- a/test/ClinicManagerTests.java
+++ b/test/ClinicManagerTests.java
@@ -3,6 +3,7 @@ import entities.Availability;
 import entities.Clinic;
 import org.junit.After;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -18,20 +19,34 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 public class ClinicManagerTests {
+
+    /**
+     * The variable representing the temporary folder where the databases used in these tests are stored until it is
+     * deleted after the tests.
+     */
     @Rule
     public TemporaryFolder databaseFolder = new TemporaryFolder();
+    private ClinicManager clinicManager;
+    private Clinic clinic;
 
+    /**
+     * Initializes the variable before each unit test.
+     */
+    @Before
+    public void before() {
+        Database originalDatabase = new Database(databaseFolder.toString());
+        clinicManager = new ClinicManager(originalDatabase);
+        clinic = new Clinic("ABC", "4169782011", "abc@gmail.com", "address",
+                new ArrayList<>(List.of(new Availability(DayOfWeek.of(1), LocalTime.of(8, 30),
+                        LocalTime.of(17, 0)))));
+        originalDatabase.setClinic(clinic);
+    }
+
+    /**
+     * Tests the clinic manager method that changes the clinic's phone number with an input that fails the regex check.
+     */
     @Test(timeout = 1000)
     public void changeClinicPhoneNumberFailsRegex(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-
-        Clinic clinic = new Clinic("ABC", "4169782011", "abc@gmail.com", "address",
-                new ArrayList<>(List.of(new Availability(DayOfWeek.of(1), LocalTime.of(8, 30),
-                LocalTime.of(17, 0)))));
-        originalDatabase.setClinic(clinic);
-
-        ClinicManager clinicManager = new ClinicManager(originalDatabase);
-
         assertEquals("The clinic phone should stay same before changing it.",
                clinic.getPhoneNumber(), "4169782011");
 
@@ -41,17 +56,11 @@ public class ClinicManagerTests {
                clinic.getPhoneNumber(), "4169782011");
     }
 
+    /**
+     * Tests the clinic manager method that changes the clinic's phone number with an input that passes the regex check.
+     */
     @Test(timeout = 1000)
     public void changeClinicPhoneNumberPassesRegex(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-
-        Clinic clinic = new Clinic("ABC", "4169782011", "abc@gmail.com", "address",
-                new ArrayList<>(List.of(new Availability(DayOfWeek.of(1), LocalTime.of(8, 30),
-                        LocalTime.of(17, 0)))));
-        originalDatabase.setClinic(clinic);
-
-        ClinicManager clinicManager = new ClinicManager(originalDatabase);
-
         assertEquals("The clinic phone should stay same before changing it.",
                 clinic.getPhoneNumber(), "4169782011");
 
@@ -61,17 +70,11 @@ public class ClinicManagerTests {
                 clinic.getPhoneNumber(), "4169782012");
     }
 
+    /**
+     * Tests the clinic manager method that changes the clinic's address.
+     */
     @Test(timeout = 1000)
-    public void changeClinicAddress(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-
-        Clinic clinic = new Clinic("ABC", "4169782011", "abc@gmail.com", "address",
-                new ArrayList<>(List.of(new Availability(DayOfWeek.of(1), LocalTime.of(8, 30),
-                        LocalTime.of(17, 0)))));
-        originalDatabase.setClinic(clinic);
-
-        ClinicManager clinicManager = new ClinicManager(originalDatabase);
-
+    public void changeClinicAddress() {
         assertEquals("The clinic address should stay same before changing it.",
                 clinic.getAddress(), "address");
 
@@ -81,17 +84,11 @@ public class ClinicManagerTests {
                 clinic.getAddress(), "abcde");
     }
 
+    /**
+     * Tests the clinic manager method that changes the clinic's name.
+     */
     @Test(timeout = 1000)
-    public void changeClinicName(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-
-        Clinic clinic = new Clinic("ABC", "4169782011", "abc@gmail.com", "address",
-                new ArrayList<>(List.of(new Availability(DayOfWeek.of(1), LocalTime.of(8, 30),
-                        LocalTime.of(17, 0)))));
-        originalDatabase.setClinic(clinic);
-
-        ClinicManager clinicManager = new ClinicManager(originalDatabase);
-
+    public void changeClinicName() {
         assertEquals("The clinic name should stay same before changing it.",
                 clinic.getName(), "ABC");
 
@@ -101,18 +98,11 @@ public class ClinicManagerTests {
                 clinic.getName(), "The Clinic");
     }
 
+    /**
+     * Tests the clinic manager method that changes the clinic's email with an input that fails the regex check.
+     */
     @Test(timeout = 1000)
-    public void changeClinicEmailAddressFailsRegex(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-
-        Clinic clinic = new Clinic("ABC", "4169782011", "abc@gmail.com", "address",
-                new ArrayList<>(List.of(new Availability(DayOfWeek.of(1), LocalTime.of(8, 30),
-                        LocalTime.of(17, 0)))));
-
-        originalDatabase.setClinic(clinic);
-
-        ClinicManager clinicManager = new ClinicManager(originalDatabase);
-
+    public void changeClinicEmailAddressFailsRegex() {
         assertEquals("The clinic address should stay same before changing it.",
                 clinic.getEmail(), "abc@gmail.com");
 
@@ -122,18 +112,11 @@ public class ClinicManagerTests {
                 clinic.getEmail(), "abc@gmail.com");
     }
 
+    /**
+     * Tests the clinic manager method that changes the clinic's email with an input that passes the regex check.
+     */
     @Test(timeout = 1000)
     public void changeClinicEmailAddressPassesRegex(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-
-        Clinic clinic = new Clinic("ABC", "4169782011", "abc@gmail.com", "address",
-                new ArrayList<>(List.of(new Availability(DayOfWeek.of(1), LocalTime.of(8, 30),
-                        LocalTime.of(17, 0)))));
-
-        originalDatabase.setClinic(clinic);
-
-        ClinicManager clinicManager = new ClinicManager(originalDatabase);
-
         assertEquals("The clinic address should stay same before changing it.",
                 clinic.getEmail(), "abc@gmail.com");
 
@@ -143,6 +126,9 @@ public class ClinicManagerTests {
                 clinic.getEmail(), "ryanm@gmail.com");
     }
 
+    /**
+     * Deletes the temporary database folder used to store the database for tests after tests are done.
+     */
     @After
     public void after() {
         DeleteUtils.deleteDirectory(new File(databaseFolder.toString()));

--- a/test/ContactManagerTests.java
+++ b/test/ContactManagerTests.java
@@ -1,221 +1,278 @@
 import dataBundles.PatientData;
 import database.Database;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.rules.TemporaryFolder;
 import useCases.ContactManager;
 import useCases.PatientManager;
 import utilities.DeleteUtils;
 
+import javax.xml.crypto.Data;
 import java.io.File;
 import java.time.LocalDate;
 
 public class ContactManagerTests {
+
+    /**
+     * The variable representing the temporary folder where the databases used in these tests are stored until it is
+     * deleted after the tests.
+     */
     @Rule
     public TemporaryFolder databaseFolder = new TemporaryFolder();
+    private Database database;
+    private ContactManager contactManager;
+    private PatientData patientData;
 
-    @Test
-    public void getContactInfoTest(){
-        Database database = new Database(databaseFolder.toString());
+    /**
+     * Initializes the variables used by all the tests before each unit test.
+     */
+    @Before
+    public void before() {
+        database = new Database(databaseFolder.toString());
         PatientManager patientManager = new PatientManager(database);
-        ContactManager contactManager = new ContactManager(database);
+        contactManager = new ContactManager(database);
+        patientData = patientManager.createPatient("dan", "iel");
 
-        PatientData patientData = patientManager.createPatient("dan", "iel");
+    }
 
+    /**
+     * Tests the contact manager method that changes a user's name.
+     */
+    @Test
+    public void testChangeName() {
+        boolean changeNameReturnValue = contactManager.changeName(
+                contactManager.getContactData(patientData), "Daniel Dervishi");
+
+        Assert.assertTrue("The change name method should return true", changeNameReturnValue);
+
+        String databaseNameField = database.getContactDatabase().get(patientData.getContactInfoId()).getName();
+
+        Assert.assertEquals("Make sure the field was updated in the contact and that the contact database" +
+                        "reflects this", databaseNameField, "Daniel Dervishi");
+    }
+
+    /**
+     * Tests the contact manager method that changes a user's email with an input that fails the regex check.
+     */
+    @Test
+    public void testChangeEmailFailsRegex() {
+        boolean changeEmailReturnValue = contactManager.changeEmail(
+                contactManager.getContactData(patientData), "Daniel Dervishi");
+
+        Assert.assertFalse("Testing method's return value", changeEmailReturnValue);
+
+        String databaseEmailField = database.getContactDatabase().get(patientData.getContactInfoId()).getEmail();
+
+        Assert.assertNull("Make sure the field was not updated in the contact and that the contact database" +
+                "reflects this", databaseEmailField);
+    }
+
+    /**
+     * Tests the contact manager method that changes a user's email with an input that passes the regex check.
+     */
+    @Test
+    public void testChangeEmailPassesRegex() {
+        boolean changeEmailReturnValue = contactManager.changeEmail(
+                contactManager.getContactData(patientData), "d.dervishi@mail.utoronto.ca");
+
+        Assert.assertTrue("Testing method's return value", changeEmailReturnValue);
+
+        String databaseEmailField = database.getContactDatabase().get(patientData.getContactInfoId()).getEmail();
+
+        Assert.assertEquals("Make sure the field was updated in the contact and that the contact database" +
+                "reflects this", databaseEmailField, "d.dervishi@mail.utoronto.ca");
+    }
+
+    /**
+     * Tests the contact manager method that changes a user's phone number with an input that fails the regex check.
+     */
+    @Test
+    public void testChangePhoneNumberFailsRegex() {
+        boolean changePhoneNumberReturnValue = contactManager.changePhoneNumber(
+                contactManager.getContactData(patientData), "(416) 978-2011");
+
+        Assert.assertFalse("Testing method's return value", changePhoneNumberReturnValue);
+
+        String databasePhoneNumberField = database.getContactDatabase().get(
+                patientData.getContactInfoId()).getPhoneNumber();
+
+        Assert.assertNull("Make sure the field was not updated in the contact and that the contact database" +
+                "reflects this", databasePhoneNumberField);
+    }
+
+    /**
+     * Tests the contact manager method that changes a user's phone number with an input that passes the regex check.
+     */
+    @Test
+    public void testChangePhoneNumberPassesRegex() {
+        boolean changePhoneNumberReturnValue = contactManager.changePhoneNumber(
+                contactManager.getContactData(patientData), "4169782011");
+
+        Assert.assertTrue("Testing method's return value", changePhoneNumberReturnValue);
+
+        String databasePhoneNumberField = database.getContactDatabase().get(
+                patientData.getContactInfoId()).getPhoneNumber();
+
+        Assert.assertEquals("Make sure the field was updated in the contact and that the contact database" +
+                "reflects this", databasePhoneNumberField, "4169782011");
+    }
+
+    /**
+     * Tests the contact manager method that changes a user's address.
+     */
+    @Test
+    public void testChangeAddress() {
+        boolean changeAddressReturnValue = contactManager.changeAddress(
+                contactManager.getContactData(patientData), "59 clown street crescent blvd");
+
+        Assert.assertTrue("Testing method's return value", changeAddressReturnValue);
+
+        String databaseAddressField = database.getContactDatabase().get(
+                patientData.getContactInfoId()).getAddress();
+
+        Assert.assertEquals("Make sure the field was updated in the contact and that the contact database" +
+                "reflects this", databaseAddressField, "59 clown street crescent blvd");
+    }
+
+    /**
+     * Tests the contact manager method that changes a user's birthday.
+     */
+    @Test
+    public void testChangeBirthday() {
+        LocalDate localDate = LocalDate.of(2007, 10, 12);
+        boolean changeBirthdayReturnValue = contactManager.changeBirthday(
+                contactManager.getContactData(patientData), localDate);
+
+        Assert.assertTrue("Testing method's return value", changeBirthdayReturnValue);
+
+        LocalDate databaseBirthdayField = database.getContactDatabase().get(
+                patientData.getContactInfoId()).getBirthday();
+
+        Assert.assertEquals("Make sure the field was updated in the contact and that the contact database" +
+                "reflects this", databaseBirthdayField, localDate);
+    }
+
+    /**
+     * Tests the contact manager method that changes a user's emergency contact email with an input that fails the
+     * regex check.
+     */
+    @Test
+    public void testChangeEmergencyEmailFailsRegex() {
+        boolean changeEmergencyEmailReturnValue = contactManager.changeEmergencyContactEmail(
+                contactManager.getContactData(patientData), "Daniel Dervishi");
+
+        Assert.assertFalse("Testing method's return value", changeEmergencyEmailReturnValue);
+
+        String databaseEmergencyEmailField = database.getContactDatabase().get(
+                patientData.getContactInfoId()).getEmergencyContactEmail();
+
+        Assert.assertNull("Make sure the field was updated in the contact and that the contact database" +
+                "reflects this", databaseEmergencyEmailField);
+    }
+
+    /**
+     * Tests the contact manager method that changes a user's emergency contact email with an input that passes the
+     * regex check.
+     */
+    @Test
+    public void testChangeEmergencyEmailPassesRegex() {
+        boolean changeEmergencyEmailReturnValue = contactManager.changeEmergencyContactEmail(
+                contactManager.getContactData(patientData), "d.dervishi@mail.utoronto.ca");
+
+        Assert.assertTrue("Testing method's return value", changeEmergencyEmailReturnValue);
+
+        String databaseEmergencyEmailField = database.getContactDatabase().get(
+                patientData.getContactInfoId()).getEmergencyContactEmail();
+
+        Assert.assertEquals("Make sure the field was updated in the contact and that the contact database" +
+                "reflects this", databaseEmergencyEmailField, "d.dervishi@mail.utoronto.ca");
+    }
+
+    /**
+     * Tests the contact manager method that changes a user's emergency contact name.
+     */
+    @Test
+    public void testChangeEmergencyContactName() {
+        boolean changeEmergencyContactNameReturnValue = contactManager.changeEmergencyContactName(
+                contactManager.getContactData(patientData), "Daniel Dervishi");
+
+        Assert.assertTrue("Testing method's return value", changeEmergencyContactNameReturnValue);
+
+        String databaseEmergencyContactNameField = database.getContactDatabase().get(
+                patientData.getContactInfoId()).getEmergencyContactName();
+
+        Assert.assertEquals("Make sure the field was updated in the contact and that the contact database" +
+                "reflects this", databaseEmergencyContactNameField, "Daniel Dervishi");
+    }
+
+    /**
+     * Tests the contact manager method that changes a user's emergency contact phone number with an input that fails
+     * the regex check.
+     */
+    @Test
+    public void testChangeEmergencyPhoneNumberFailsRegex() {
+        boolean changeEmergencyPhoneNumberReturnValue = contactManager.changeEmergencyContactPhoneNumber(
+                contactManager.getContactData(patientData), "(416) 978-2011");
+
+        Assert.assertFalse("Testing method's return value", changeEmergencyPhoneNumberReturnValue);
+
+        String databaseEmergencyPhoneNumberField = database.getContactDatabase().get(
+                patientData.getContactInfoId()).getEmergencyContactPhoneNumber();
+
+        Assert.assertNull("Make sure the field was not updated in the contact and that the contact database" +
+                "reflects this", databaseEmergencyPhoneNumberField);
+    }
+
+    /**
+     * Tests the contact manager method that changes a user's emergency contact phone number with an input that passes
+     * the regex check.
+     */
+    @Test
+    public void testChangeEmergencyPhoneNumberPassesRegex() {
+        boolean changeEmergencyPhoneNumberReturnValue = contactManager.changeEmergencyContactPhoneNumber(
+                contactManager.getContactData(patientData), "4169782011");
+
+        Assert.assertTrue("Testing method's return value", changeEmergencyPhoneNumberReturnValue);
+
+        String databaseEmergencyPhoneNumberField = database.getContactDatabase().get(
+                patientData.getContactInfoId()).getEmergencyContactPhoneNumber();
+
+        Assert.assertEquals("Make sure the field was updated in the contact and that the contact database" +
+                "reflects this", databaseEmergencyPhoneNumberField, "4169782011");
+    }
+
+    /**
+     * Tests the contact manager method that changes a user's emergency relationship.
+     */
+    @Test
+    public void testChangeEmergencyRelationship() {
+        boolean changeEmergencyPhoneNumberReturnRelationship = contactManager.changeEmergencyRelationship(
+                contactManager.getContactData(patientData), "Father");
+
+        Assert.assertTrue("Testing method's return value", changeEmergencyPhoneNumberReturnRelationship);
+
+        String databaseEmergencyRelationshipField = database.getContactDatabase().get(
+                patientData.getContactInfoId()).getEmergencyRelationship();
+
+        Assert.assertEquals("Make sure the field was updated in the contact and that the contact database" +
+                "reflects this", databaseEmergencyRelationshipField, "Father");
+    }
+
+    /**
+     * Tests the contact manager getter method that returns a user's contact info.
+     */
+    @Test
+    public void getContactInfoTest() {
         Assert.assertEquals("Test to see if the contact id stored in the patient is the same as the one" +
                         "retrieved when getting contact info by username through contact manager.",
                 contactManager.getContactData(patientData).getContactId(), patientData.getContactInfoId());
     }
-    @Test
-    public void testChangeName(){
-        Database database = new Database(databaseFolder.toString());
-        PatientManager patientManager = new PatientManager(database);
-        ContactManager contactManager = new ContactManager(database);
 
-        PatientData patientData = patientManager.createPatient("dan", "iel");
-
-        Assert.assertTrue("The change name method should return true",
-                contactManager.changeName(contactManager.getContactData(patientData), "Daniel Dervishi"));
-        Assert.assertEquals("Make sure the field was updated in the contact and that the contact database" +
-                        "reflects this",
-                database.getContactDatabase().get(patientData.getContactInfoId()).getName(), "Daniel Dervishi");
-    }
-    @Test
-    public void testChangeEmailFailsRegex(){
-        Database database = new Database(databaseFolder.toString());
-        PatientManager patientManager = new PatientManager(database);
-        ContactManager contactManager = new ContactManager(database);
-
-        PatientData patientData = patientManager.createPatient("dan", "iel");
-
-        Assert.assertFalse("Testing method's return value",
-                contactManager.changeEmail(contactManager.getContactData(patientData), "Daniel Dervishi"));
-        Assert.assertNull("Make sure the field was not updated in the contact and that the contact database" +
-                "reflects this", database.getContactDatabase().get(patientData.getContactInfoId()).getEmail());
-    }
-
-    @Test
-    public void testChangeEmailPassesRegex(){
-        Database database = new Database(databaseFolder.toString());
-        PatientManager patientManager = new PatientManager(database);
-        ContactManager contactManager = new ContactManager(database);
-
-        PatientData patientData = patientManager.createPatient("dan", "iel");
-
-        Assert.assertTrue("Testing method's return value",
-                contactManager.changeEmail(contactManager.getContactData(patientData), "d.dervishi@mail.utoronto.ca"));
-        Assert.assertEquals("Make sure the field was updated in the contact and that the contact database" +
-                "reflects this", database.getContactDatabase().get(patientData.getContactInfoId()).getEmail(), "d.dervishi@mail.utoronto.ca");
-    }
-
-    @Test
-    public void testChangePhoneNumberFailsRegex(){
-        Database database = new Database(databaseFolder.toString());
-        PatientManager patientManager = new PatientManager(database);
-        ContactManager contactManager = new ContactManager(database);
-
-        PatientData patientData = patientManager.createPatient("dan", "iel");
-
-        Assert.assertFalse("Testing method's return value",
-                contactManager.changePhoneNumber(contactManager.getContactData(patientData), "(416) 978-2011"));
-        Assert.assertNull("Make sure the field was not updated in the contact and that the contact database" +
-                "reflects this", database.getContactDatabase().get(patientData.getContactInfoId()).getPhoneNumber());
-    }
-
-    @Test
-    public void testChangePhoneNumberPassesRegex(){
-        Database database = new Database(databaseFolder.toString());
-        PatientManager patientManager = new PatientManager(database);
-        ContactManager contactManager = new ContactManager(database);
-
-        PatientData patientData = patientManager.createPatient("dan", "iel");
-
-        Assert.assertTrue("Testing method's return value",
-                contactManager.changePhoneNumber(contactManager.getContactData(patientData), "4169782011"));
-        Assert.assertEquals("Make sure the field was updated in the contact and that the contact database" +
-                        "reflects this"
-                , database.getContactDatabase().get(patientData.getContactInfoId()).getPhoneNumber(), "4169782011");
-    }
-
-    @Test
-    public void testChangeAddress(){
-        Database database = new Database(databaseFolder.toString());
-        PatientManager patientManager = new PatientManager(database);
-        ContactManager contactManager = new ContactManager(database);
-
-        PatientData patientData = patientManager.createPatient("dan", "iel");
-
-        Assert.assertTrue("Testing method's return value",
-                contactManager.changeAddress(contactManager.getContactData(patientData), "59 clown street crescent blvd"));
-        Assert.assertEquals("Make sure the field was updated in the contact and that the contact database" +
-                "reflects this", database.getContactDatabase().get(patientData.getContactInfoId()).getAddress(), "59 clown street crescent blvd");
-    }
-
-    @Test
-    public void testChangeBirthday(){
-        Database database = new Database(databaseFolder.toString());
-        PatientManager patientManager = new PatientManager(database);
-        ContactManager contactManager = new ContactManager(database);
-        LocalDate localDate = LocalDate.of(2007, 10, 12);
-
-        PatientData patientData = patientManager.createPatient("dan", "iel");
-
-
-        Assert.assertTrue("Testing method's return value",
-                contactManager.changeBirthday(contactManager.getContactData(patientData),localDate));
-        Assert.assertEquals("Make sure the field was updated in the contact and that the contact database" +
-                "reflects this",database.getContactDatabase().get(patientData.getContactInfoId()).getBirthday(), localDate);
-    }
-
-    @Test
-    public void testChangeEmergencyEmailFailsRegex(){
-        Database database = new Database(databaseFolder.toString());
-        PatientManager patientManager = new PatientManager(database);
-        ContactManager contactManager = new ContactManager(database);
-
-        PatientData patientData = patientManager.createPatient("dan", "iel");
-
-        Assert.assertFalse("Testing method's return value",
-                contactManager.changeEmergencyContactEmail(contactManager.getContactData(patientData),
-                        "Daniel Dervishi"));
-        Assert.assertNull("Make sure the field was updated in the contact and that the contact database" +
-                "reflects this", database.getContactDatabase().get(patientData.getContactInfoId()).getEmergencyContactEmail());
-    }
-
-    @Test
-    public void testChangeEmergencyEmailPassesRegex(){
-        Database database = new Database(databaseFolder.toString());
-        PatientManager patientManager = new PatientManager(database);
-        ContactManager contactManager = new ContactManager(database);
-
-        PatientData patientData = patientManager.createPatient("dan", "iel");
-
-        Assert.assertTrue("Testing method's return value",
-                contactManager.changeEmergencyContactEmail(contactManager.getContactData(patientData), "d.dervishi@mail.utoronto.ca"));
-        Assert.assertEquals("Make sure the field was updated in the contact and that the contact database" +
-                "reflects this", database.getContactDatabase().get(patientData.getContactInfoId()).getEmergencyContactEmail(), "d.dervishi@mail.utoronto.ca");
-    }
-
-    @Test
-    public void testChangeEmergencyContactName(){
-        Database database = new Database(databaseFolder.toString());
-        PatientManager patientManager = new PatientManager(database);
-        ContactManager contactManager = new ContactManager(database);
-
-        PatientData patientData = patientManager.createPatient("dan", "iel");
-
-        Assert.assertTrue("Testing method's return value",
-                contactManager.changeEmergencyContactName(contactManager.getContactData(patientData), "Daniel Dervishi"));
-        Assert.assertEquals("Make sure the field was updated in the contact and that the contact database" +
-                "reflects this", database.getContactDatabase().get(patientData.getContactInfoId()).getEmergencyContactName(), "Daniel Dervishi");
-    }
-
-    @Test
-    public void testChangeEmergencyPhoneNumberFailsRegex(){
-        Database database = new Database(databaseFolder.toString());
-        PatientManager patientManager = new PatientManager(database);
-        ContactManager contactManager = new ContactManager(database);
-
-        PatientData patientData = patientManager.createPatient("dan", "iel");
-
-        Assert.assertFalse("Testing method's return value",
-                contactManager.changeEmergencyContactPhoneNumber(contactManager.getContactData(patientData), "(416) 978-2011"));
-        Assert.assertNull("Make sure the field was not updated in the contact and that the contact database" +
-                "reflects this", database.getContactDatabase().get(patientData.getContactInfoId()).getEmergencyContactPhoneNumber());
-    }
-
-    @Test
-    public void testChangeEmergencyPhoneNumberPassesRegex(){
-        Database database = new Database(databaseFolder.toString());
-        PatientManager patientManager = new PatientManager(database);
-        ContactManager contactManager = new ContactManager(database);
-
-        PatientData patientData = patientManager.createPatient("dan", "iel");
-
-        Assert.assertTrue("Testing method's return value",
-                contactManager.changeEmergencyContactPhoneNumber(contactManager.getContactData(patientData), "4169782011"));
-        Assert.assertEquals("Make sure the field was updated in the contact and that the contact database" +
-                "reflects this", database.getContactDatabase().get(patientData.getContactInfoId()).getEmergencyContactPhoneNumber(), "4169782011");
-    }
-
-    @Test
-    public void testChangeEmergencyRelationship(){
-        Database database = new Database(databaseFolder.toString());
-        PatientManager patientManager = new PatientManager(database);
-        ContactManager contactManager = new ContactManager(database);
-
-        PatientData patientData = patientManager.createPatient("dan", "iel");
-
-        Assert.assertTrue("Testing method's return value",
-                contactManager.changeEmergencyRelationship(contactManager.getContactData(patientData), "Father"));
-        Assert.assertEquals("Make sure the field was updated in the contact and that the contact database" +
-                "reflects this", database.getContactDatabase().get(patientData.getContactInfoId()).getEmergencyRelationship(), "Father");
-    }
-
+    /**
+     * Deletes the temporary database folder used to store the database for tests after tests are done.
+     */
     @After
     public void after() {
         DeleteUtils.deleteDirectory(new File(databaseFolder.toString()));
     }
+
 }

--- a/test/ContactManagerTests.java
+++ b/test/ContactManagerTests.java
@@ -33,7 +33,7 @@ public class ContactManagerTests {
         database = new Database(databaseFolder.toString());
         PatientManager patientManager = new PatientManager(database);
         contactManager = new ContactManager(database);
-        patientData = patientManager.createPatient("dan", "iel");
+        patientData = patientManager.createPatient("danieldervy", "123456789");
 
     }
 

--- a/test/ContactManagerTests.java
+++ b/test/ContactManagerTests.java
@@ -10,6 +10,9 @@ import javax.xml.crypto.Data;
 import java.io.File;
 import java.time.LocalDate;
 
+/**
+ * Class of unit tests for ContactManager use case class.
+ */
 public class ContactManagerTests {
 
     /**

--- a/test/DatabaseTests.java
+++ b/test/DatabaseTests.java
@@ -11,6 +11,9 @@ import java.io.File;
 import java.time.*;
 import java.util.ArrayList;
 
+/**
+ * Class of unit tests for the program's databases.
+ */
 public class DatabaseTests {
 
     /**

--- a/test/DatabaseTests.java
+++ b/test/DatabaseTests.java
@@ -13,19 +13,32 @@ import java.util.ArrayList;
 
 public class DatabaseTests {
 
+    /**
+     * The variable representing the temporary folder where the databases used in these tests are stored until it is
+     * deleted after the tests.
+     */
     @Rule
     public TemporaryFolder databaseFolder = new TemporaryFolder();
+    private Database originalDatabase;
 
+    /**
+     * Initializes the variables used by all the tests before each unit test.
+     */
+    @Before
+    public void before() {
+        originalDatabase = new Database(databaseFolder.toString());
+    }
+
+    /**
+     * Tests the saving and loading functionality of patient databases.
+     */
     @Test(timeout = 1000)
     public void testSaveLoadPatientDatabase() {
-        Database originalDatabase = new Database(databaseFolder.toString());
         DataMapperGateway<Patient> originalPatientDatabase = originalDatabase.getPatientDatabase();
 
-        Patient originalPatient = new
-                Patient("jeff", "123", 123456789, "5544");
+        Patient originalPatient = new Patient("jeff", "123", 123456789, "5544");
 
         Integer patientID = originalPatientDatabase.add(originalPatient);
-
         originalPatientDatabase.save();
 
         Database loadedDatabase = new Database(databaseFolder.toString());
@@ -47,9 +60,11 @@ public class DatabaseTests {
                 loadedPatient.comparePassword("123"));
     }
 
+    /**
+     * Tests the saving and loading functionality of doctor databases.
+     */
     @Test(timeout = 1000)
     public void testSaveLoadDoctorDatabase() {
-        Database originalDatabase = new Database(databaseFolder.toString());
         DataMapperGateway<Doctor> originalDoctorDatabase = originalDatabase.getDoctorDatabase();
 
         Doctor originalDoctor = new
@@ -73,9 +88,11 @@ public class DatabaseTests {
                 loadedDoctor.comparePassword("123"));
     }
 
+    /**
+     * Tests the saving and loading functionality of secretary databases.
+     */
     @Test(timeout = 1000)
     public void testSaveLoadSecretaryDatabase() {
-        Database originalDatabase = new Database(databaseFolder.toString());
         DataMapperGateway<Secretary> originalSecretaryDatabase = originalDatabase.getSecretaryDatabase();
 
         Secretary originalSecretary = new
@@ -99,9 +116,11 @@ public class DatabaseTests {
                 loadedSecretary.comparePassword("123"));
     }
 
+    /**
+     * Tests the saving and loading functionality of admin databases.
+     */
     @Test(timeout = 1000)
     public void testSaveLoadAdminDatabase() {
-        Database originalDatabase = new Database(databaseFolder.toString());
         DataMapperGateway<Admin> originalAdminDatabase = originalDatabase.getAdminDatabase();
 
         Admin originalAdmin = new
@@ -125,9 +144,11 @@ public class DatabaseTests {
                 loadedAdmin.comparePassword("123"));
     }
 
+    /**
+     * Tests the saving and loading functionality of prescription databases.
+     */
     @Test(timeout = 1000)
     public void testSaveLoadPrescriptionDatabase() {
-        Database originalDatabase = new Database(databaseFolder.toString());
         DataMapperGateway<Prescription> originalPrescriptionDatabase = originalDatabase.getPrescriptionDatabase();
 
         LocalDate localExpiryDate = LocalDate.of(2024, 7, 1);
@@ -162,9 +183,11 @@ public class DatabaseTests {
                 getExpiryDate()), 0);
     }
 
+    /**
+     * Tests the saving and loading functionality of report databases.
+     */
     @Test(timeout = 1000)
     public void testSaveLoadReportDatabase() {
-        Database originalDatabase = new Database(databaseFolder.toString());
         DataMapperGateway<Report> originalReportDatabase = originalDatabase.getReportDatabase();
 
         Report originalReport = new
@@ -194,9 +217,11 @@ public class DatabaseTests {
                 originalReport.getDoctorId(), loadedReport.getDoctorId());
     }
 
+    /**
+     * Tests the saving and loading functionality of appointment databases.
+     */
     @Test(timeout = 1000)
     public void testSaveLoadAppointmentDatabase() {
-        Database originalDatabase = new Database(databaseFolder.toString());
         DataMapperGateway<Appointment> originalAppointmentDatabase = originalDatabase.getAppointmentDatabase();
 
         LocalDateTime localStartTime = LocalDateTime.of(2022,7,1,4,3);
@@ -227,9 +252,11 @@ public class DatabaseTests {
                 originalAppointment.getDoctorId(), loadedAppointment.getDoctorId());
     }
 
+    /**
+     * Tests the saving and loading functionality of log databases.
+     */
     @Test(timeout = 1000)
     public void testSaveLoadLogDatabase() {
-        Database originalDatabase = new Database(databaseFolder.toString());
         DataMapperGateway<Log> originalLogDatabase = originalDatabase.getLogDatabase();
 
         Log originalLog = new Log(21, "jeff");
@@ -252,9 +279,11 @@ public class DatabaseTests {
                 originalLog.getMessage(), loadedLog.getMessage());
     }
 
+    /**
+     * Tests the saving and loading functionality of contact databases.
+     */
     @Test(timeout = 1000)
     public void testSaveLoadContactDatabase() {
-        Database originalDatabase = new Database(databaseFolder.toString());
         DataMapperGateway<Contact> originalContactDatabase = originalDatabase.getContactDatabase();
 
         LocalDate birthday = LocalDate.of(2022, 1, 1);
@@ -292,10 +321,11 @@ public class DatabaseTests {
                 originalContact.getEmergencyRelationship(), loadedContact.getEmergencyRelationship());
     }
 
+    /**
+     * Tests the getting and setting clinic entity functionality of main database of the program.
+     */
     @Test(timeout = 1000)
     public void testSetGetClinic() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-
         ArrayList<Availability> clinicHours = new ArrayList<>();
         clinicHours.add(new Availability(DayOfWeek.of(1), LocalTime.of(8, 0), LocalTime.of(20, 0)));
         Clinic originalClinic = new Clinic("jeff clinic",  "12345678", "abc@gmail.com",
@@ -324,8 +354,12 @@ public class DatabaseTests {
                         getDoctorEndTime()), 0);
     }
 
+    /**
+     * Deletes the temporary database folder used to store the database for tests after tests are done.
+     */
     @After
     public void after() {
         DeleteUtils.deleteDirectory(new File(databaseFolder.toString()));
     }
+
 }

--- a/test/DatabaseTests.java
+++ b/test/DatabaseTests.java
@@ -23,6 +23,8 @@ public class DatabaseTests {
     @Rule
     public TemporaryFolder databaseFolder = new TemporaryFolder();
     private Database originalDatabase;
+    private final String username = "mynamejeff";
+    private final String password = "123456789";
 
     /**
      * Initializes the variables used by all the tests before each unit test.
@@ -39,7 +41,7 @@ public class DatabaseTests {
     public void testSaveLoadPatientDatabase() {
         DataMapperGateway<Patient> originalPatientDatabase = originalDatabase.getPatientDatabase();
 
-        Patient originalPatient = new Patient("jeff", "123", 123456789, "5544");
+        Patient originalPatient = new Patient(username, password, 123456789, "5544");
 
         Integer patientID = originalPatientDatabase.add(originalPatient);
         originalPatientDatabase.save();
@@ -60,7 +62,7 @@ public class DatabaseTests {
         assertEquals("Original patient and loaded patient should share the same health numbers",
                 originalPatient.getHealthNumber(), loadedPatient.getHealthNumber());
         assertTrue("Original patient and loaded patient should share the same password",
-                loadedPatient.comparePassword("123"));
+                loadedPatient.comparePassword(password));
     }
 
     /**
@@ -71,7 +73,7 @@ public class DatabaseTests {
         DataMapperGateway<Doctor> originalDoctorDatabase = originalDatabase.getDoctorDatabase();
 
         Doctor originalDoctor = new
-                Doctor("jeff", "123", 123456789);
+                Doctor(username, password, 123456789);
 
         Integer doctorID = originalDoctorDatabase.add(originalDoctor);
         originalDoctorDatabase.save();
@@ -88,7 +90,7 @@ public class DatabaseTests {
         assertEquals("Original doctor and loaded doctor should share the same contact information",
                 originalDoctor.getContactInfoId(), loadedDoctor.getContactInfoId());
         assertTrue("Original doctor and loaded doctor should share the same password",
-                loadedDoctor.comparePassword("123"));
+                loadedDoctor.comparePassword(password));
     }
 
     /**
@@ -99,7 +101,7 @@ public class DatabaseTests {
         DataMapperGateway<Secretary> originalSecretaryDatabase = originalDatabase.getSecretaryDatabase();
 
         Secretary originalSecretary = new
-                Secretary("jeff", "123", 123456789);
+                Secretary(username, password, 123456789);
 
         Integer secretaryID = originalSecretaryDatabase.add(originalSecretary);
         originalSecretaryDatabase.save();
@@ -116,7 +118,7 @@ public class DatabaseTests {
         assertEquals("Original secretary and loaded secretary should share the same contact information",
                 originalSecretary.getContactInfoId(), loadedSecretary.getContactInfoId());
         assertTrue("Original secretary and loaded secretary should share the same password",
-                loadedSecretary.comparePassword("123"));
+                loadedSecretary.comparePassword(password));
     }
 
     /**
@@ -127,7 +129,7 @@ public class DatabaseTests {
         DataMapperGateway<Admin> originalAdminDatabase = originalDatabase.getAdminDatabase();
 
         Admin originalAdmin = new
-                Admin("jeff", "123", 123456789);
+                Admin(username, password, 123456789);
 
         Integer adminID = originalAdminDatabase.add(originalAdmin);
         originalAdminDatabase.save();
@@ -144,7 +146,7 @@ public class DatabaseTests {
         assertEquals("Original admin and loaded admin should share the same contact information",
                 originalAdmin.getContactInfoId(), loadedAdmin.getContactInfoId());
         assertTrue("Original admin and loaded admin should share the same password",
-                loadedAdmin.comparePassword("123"));
+                loadedAdmin.comparePassword(password));
     }
 
     /**
@@ -262,7 +264,7 @@ public class DatabaseTests {
     public void testSaveLoadLogDatabase() {
         DataMapperGateway<Log> originalLogDatabase = originalDatabase.getLogDatabase();
 
-        Log originalLog = new Log(21, "jeff");
+        Log originalLog = new Log(21, username);
 
         Integer logID = originalLogDatabase.add(originalLog);
         originalLogDatabase.save();
@@ -290,7 +292,7 @@ public class DatabaseTests {
         DataMapperGateway<Contact> originalContactDatabase = originalDatabase.getContactDatabase();
 
         LocalDate birthday = LocalDate.of(2022, 1, 1);
-        Contact originalContact = new Contact("jeff", "jeff@gmail.com", "12345678",
+        Contact originalContact = new Contact(username, "jeff@gmail.com", "12345678",
                 "jeff street", birthday, "jim", "jim@gmail.com",
                 "87654321", "father");
 

--- a/test/DoctorManagerTests.java
+++ b/test/DoctorManagerTests.java
@@ -76,9 +76,15 @@ public class DoctorManagerTests {
      */
     @Test(timeout = 1000)
     public void testCreateDoctorInvalidFormat() {
-        assertThrows("creating a user with a non-alphanumeric username and a password shorter than 8 " +
-                        "characters will return an illegal argument exception", IllegalArgumentException.class,
-                () -> doctorManager.createDoctor("!!!", "123"));
+        assertThrows("creating a user with a non-alphanumeric username characters will return an illegal " +
+                        "argument exception", IllegalArgumentException.class,
+                () -> doctorManager.createDoctor("newuser!", "123456789"));
+        assertThrows("creating a user with a username shorter than 6 characters will return an illegal " +
+                        "argument exception", IllegalArgumentException.class,
+                () -> doctorManager.createDoctor("newu", "123456789"));
+        assertThrows("creating a user with a password shorter than 8 characters will return an illegal " +
+                        "argument exception", IllegalArgumentException.class,
+                () -> doctorManager.createDoctor("newuser1", "1234567"));
     }
 
     /**

--- a/test/DoctorManagerTests.java
+++ b/test/DoctorManagerTests.java
@@ -14,6 +14,9 @@ import java.io.File;
 
 import static org.junit.Assert.*;
 
+/**
+ * Class of unit tests for DoctorManager use case class.
+ */
 public class DoctorManagerTests {
 
     /**

--- a/test/DoctorManagerTests.java
+++ b/test/DoctorManagerTests.java
@@ -1,9 +1,9 @@
 import dataBundles.DoctorData;
-import dataBundles.ContactData;
 import database.DataMapperGateway;
 import database.Database;
 import entities.Doctor;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -11,284 +11,224 @@ import useCases.DoctorManager;
 import utilities.DeleteUtils;
 
 import java.io.File;
-import java.time.LocalDate;
 
 import static org.junit.Assert.*;
 
 public class DoctorManagerTests {
 
+    /**
+     * The variable representing the temporary folder where the databases used in these tests are stored until it is
+     * deleted after the tests.
+     */
     @Rule
     public TemporaryFolder databaseFolder = new TemporaryFolder();
+    private DataMapperGateway<Doctor> doctorDatabase;
+    private DoctorManager doctorManager;
+    private DoctorData doctorData;
 
+    /**
+     * Initializes the variables used by all the tests before each unit test.
+     */
+    @Before
+    public void before() {
+        Database database = new Database(databaseFolder.toString());
+        doctorDatabase = database.getDoctorDatabase();
+        doctorManager = new DoctorManager(database);
+        doctorData = doctorManager.createDoctor("jeff", "123");
+    }
+
+    /**
+     * Tests the doctor manager's method that creates a new doctor data bundle with a non-existing username.
+     */
     @Test(timeout = 1000)
-    public void testCreateDoctorValid() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Doctor> doctorDatabase = originalDatabase.getDoctorDatabase();
-
-        String username = "jeff";
-        String password = "123";
-        LocalDate birthday = LocalDate.of(2022, 1, 1);
-        ContactData contactData = new ContactData("jeff", "jeff@gmail.com",
-                "12345678", "jeff street", birthday, "jim",
-                "jim@gmail.com", "87654321",
-                "father");
-
-        DoctorManager doctorManager = new DoctorManager(originalDatabase);
-
-        DoctorData doctorData = doctorManager.createDoctor(username, password);
-
+    public void testCreateDoctorValidUsername() {
         /* Testing if the return doctor data is valid by testing if the fields of are equal to the parameters of
         createDoctor */
         assertEquals("The created doctor data should have the same name as the parameters of " +
-                "createDoctor method", doctorData.getUsername(), username);
+                "createDoctor method", doctorData.getUsername(), "jeff");
 
         Doctor loadedDoctor = doctorDatabase.get(doctorData.getId());
 
         /* Testing if the doctor object has been correctly added to the database by testing if the fields of the loaded
         doctor are equal to the parameters of createDoctor */
         assertEquals("Original doctor and loaded doctor should share the same unique username",
-                loadedDoctor.getUsername(), username);
+                loadedDoctor.getUsername(), "jeff");
         assertTrue("Original doctor and loaded doctor should share the same password",
-                loadedDoctor.comparePassword(password));
+                loadedDoctor.comparePassword("123"));
     }
+
+    /**
+     * Tests the doctor manager's method that creates a new doctor data bundle with an existing username.
+     */
     @Test(timeout = 1000)
-    public void testCreateDoctorInvalid() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Doctor> doctorDatabase = originalDatabase.getDoctorDatabase();
-
-        String username = "jeff";
-        String password = "123";
-        LocalDate birthday = LocalDate.of(2022, 1, 1);
-        ContactData contactData = new ContactData("jeff", "jeff@gmail.com",
-                "12345678", "jeff street", birthday, "jim",
-                "jim@gmail.com", "87654321",
-                "father");
-
-        DoctorManager doctorManager = new DoctorManager(originalDatabase);
-
-        DoctorData doctorData = doctorManager.createDoctor(username, password);
-
+    public void testCreateDoctorInvalidUsername() {
         assertNull("creating a user with the same name and password already existing in the database " +
-                "should return null", doctorManager.createDoctor(username, password));
+                "should return null", doctorManager.createDoctor("jeff", "123"));
     }
 
+    /**
+     * Tests the doctor manager's method that deletes a doctor with an existing username.
+     */
     @Test(timeout = 1000)
-    public void testDeleteDoctor() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Doctor> doctorDatabase = originalDatabase.getDoctorDatabase();
-
-        Doctor doctor = new
-                Doctor("jeff", "123", 123456789);
-
-        DoctorManager doctorManager = new DoctorManager(originalDatabase);
-
-        Integer doctorID = doctorDatabase.add(doctor);
-
+    public void testDeleteDoctorValidUsername() {
         assertNotNull("A doctor object should be returned before it is deleted ",
-                doctorDatabase.get(doctorID));
+                doctorDatabase.get(doctorData.getId()));
 
-        doctorManager.deleteUser(doctor.getUsername());
+        boolean deleteDoctorReturnValue = doctorManager.deleteUser(doctorData.getUsername());
 
+        assertTrue("The method should return true when the username exists", deleteDoctorReturnValue);
         assertNull("A doctor object should not be returned after it is deleted ",
-                doctorDatabase.get(doctorID));
+                doctorDatabase.get(doctorData.getId()));
     }
+
+    /**
+     * Tests the doctor manager's method that deletes a doctor with a non-existent username.
+     */
     @Test(timeout = 1000)
-    public void getUserData() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Doctor> doctorDatabase = originalDatabase.getDoctorDatabase();
+    public void testDeleteDoctorInvalidUsername() {
+        boolean deleteDoctorReturnValue = doctorManager.deleteUser("jim");
 
-        Doctor doctor = new
-                Doctor("jeff", "123", 123456789);
+        assertFalse("The method should return false when the username does not exist", deleteDoctorReturnValue);
+    }
 
-        DoctorManager doctorManager = new DoctorManager(originalDatabase);
-
-        Integer doctorID = doctorDatabase.add(doctor);
-
-        DoctorData doctorData = doctorManager.getUserData(doctor.getUsername());
+    /**
+     * Tests the doctor manager's getter method that returns a data bundle of a doctor user with an existing username.
+     */
+    @Test(timeout = 1000)
+    public void getUserDataValidUsername() {
+        DoctorData loadedDoctorData = doctorManager.getUserData(doctorData.getUsername());
 
         /* Testing if the doctorData and the original doctor are equal by testing whether all the fields of both
         objects are equal */
         assertEquals("doctor and doctorData should share the same Id",
-                doctor.getId(), doctorData.getId());
+                doctorData.getId(), loadedDoctorData.getId());
         assertEquals("doctor and doctorData should share the same unique username",
-                doctor.getUsername(), doctorData.getUsername());
+                doctorData.getUsername(), loadedDoctorData.getUsername());
         assertEquals("doctor and doctorData should share the same contact information",
-                doctor.getContactInfoId(), doctorData.getContactInfoId());
-        assertTrue("doctor and doctorData should share the same password",
-                doctor.comparePassword("123"));
+                doctorData.getContactInfoId(), loadedDoctorData.getContactInfoId());
     }
-    @Test(timeout = 1000)
-    public void getUserDataInvalid() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DoctorManager doctorManager = new DoctorManager(originalDatabase);
 
+    /**
+     * Tests the doctor manager's getter method that returns a data bundle of a doctor user with a non-existent username.
+     */
+    @Test(timeout = 1000)
+    public void getUserDataInvalidUsername() {
         assertNull("trying to get user data of a user that doesn't exist should return null",
                 doctorManager.getUserData("jim"));
 
     }
+
+    /**
+     * Tests the doctor manager's method that deletes a doctor by passing in a doctor data bundle.
+     */
     @Test(timeout = 1000)
     public void testDeleteDoctorByData() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Doctor> doctorDatabase = originalDatabase.getDoctorDatabase();
-
-        Doctor doctor = new
-                Doctor("jeff", "123", 123456789);
-
-        DoctorManager doctorManager = new DoctorManager(originalDatabase);
-
-        Integer doctorID = doctorDatabase.add(doctor);
-        DoctorData userdata = doctorManager.getUserData(doctor.getUsername());
+        DoctorData loadedDoctorData = doctorManager.getUserData(doctorData.getUsername());
 
         assertNotNull("A doctor object should be returned before it is deleted ",
-                doctorDatabase.get(doctorID));
+                doctorDatabase.get(doctorData.getId()));
 
-        doctorManager.deleteUserByData(userdata);
+        doctorManager.deleteUserByData(loadedDoctorData);
 
         assertNull("A doctor object should not be returned after it is deleted by data",
-                doctorDatabase.get(doctorID));
+                doctorDatabase.get(doctorData.getId()));
     }
 
+    /**
+     * Tests the doctor manager's method that changes a doctor's password.
+     */
     @Test(timeout = 1000)
     public void testChangeUserPassword() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Doctor> doctorDatabase = originalDatabase.getDoctorDatabase();
-
-        Doctor doctor = new
-                Doctor("jeff", "123", 123456789);
-
-        DoctorManager doctorManager = new DoctorManager(originalDatabase);
-
-        Integer doctorID = doctorDatabase.add(doctor);
-        DoctorData doctorData = new DoctorData(doctor);
-
         assertTrue("The password should remain the same before the change ",
-                doctorDatabase.get(doctorID).comparePassword("123"));
+                doctorDatabase.get(doctorData.getId()).comparePassword("123"));
 
         doctorManager.changeUserPassword(doctorData, "456");
 
         assertTrue("The doctor object should have the same password as we inputted into the parameters " +
                         "of the changeUserPassword method ",
-                doctorDatabase.get(doctorID).comparePassword("456"));
+                doctorDatabase.get(doctorData.getId()).comparePassword("456"));
     }
 
+    /**
+     * Tests the doctor manager's getter method that returns a data bundle of the doctor.
+     */
     @Test(timeout = 1000)
     public void testGetDoctor() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Doctor> doctorDatabase = originalDatabase.getDoctorDatabase();
-
-        Doctor originalDoctor = new
-                Doctor("jeff", "123", 123456789);
-
-        DoctorManager doctorManager = new DoctorManager(originalDatabase);
-
-        Integer doctorID = doctorDatabase.add(originalDoctor);
-
-        assertEquals("Original doctor should share the same ID from the database",
-                originalDoctor.getId(), doctorID);
-
-        Doctor loadedDoctor = doctorDatabase.get(originalDoctor.getId());
+        Doctor loadedDoctor = doctorDatabase.get(doctorData.getId());
         /* Testing if the loaded doctor and the original doctor are equal by testing whether all the fields of both
         objects are equal */
         assertEquals("Original doctor and loaded doctor should share the same Id",
-                originalDoctor.getId(), loadedDoctor.getId());
+                doctorData.getId(), loadedDoctor.getId());
         assertEquals("Original doctor and loaded doctor should share the same unique username",
-                originalDoctor.getUsername(), loadedDoctor.getUsername());
+                doctorData.getUsername(), loadedDoctor.getUsername());
         assertEquals("Original doctor and loaded doctor should share the same contact information",
-                originalDoctor.getContactInfoId(), loadedDoctor.getContactInfoId());
+                doctorData.getContactInfoId(), loadedDoctor.getContactInfoId());
         assertTrue("Original doctor and loaded doctor should share the same password",
                 loadedDoctor.comparePassword("123"));
     }
 
+    /**
+     * Tests the doctor manager's method that checks if a doctor with a username exists using an existing username.
+     */
     @Test(timeout = 1000)
     public void testDoesUserExist(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Doctor> doctorDatabase = originalDatabase.getDoctorDatabase();
-
-        Doctor doctor = new
-                Doctor("jeff", "123", 123456789);
-
-        DoctorManager doctorManager = new DoctorManager(originalDatabase);
-        Integer doctorId = doctorDatabase.add(doctor);
-
         assertNotNull("A doctor object should be returned when added to the database",
-                doctorDatabase.get(doctorId));
+                doctorDatabase.get(doctorData.getId()));
         assertTrue("DoesUserExist should return true since the doctor is stored in the database",
-                doctorManager.doesUserExist(doctor.getUsername()));
+                doctorManager.doesUserExist(doctorData.getUsername()));
     }
+
+    /**
+     * Tests the doctor manager's method that checks if a doctor with a username exists using a non-existent username.
+     */
     @Test(timeout = 1000)
     public void testUserDoesNotExist(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Doctor> doctorDatabase = originalDatabase.getDoctorDatabase();
-
-        Doctor doctor = new
-                Doctor("jeff", "123", 123456789);
-
-        DoctorManager doctorManager = new DoctorManager(originalDatabase);
-        Integer doctorId = doctorDatabase.add(doctor);
-
         assertFalse("DoesUserExist should return false if there is no account stored in the database with the" +
                         "inputted username",
                 doctorManager.doesUserExist("jim"));
     }
+
+    /**
+     * Tests the doctor manager's method that checks if a doctor can sign in using valid login details.
+     */
     @Test(timeout = 1000)
-    public void testCanSignInValid(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Doctor> doctorDatabase = originalDatabase.getDoctorDatabase();
-
-        Doctor doctor = new
-                Doctor("jeff", "123", 123456789);
-
-        DoctorManager doctorManager = new DoctorManager(originalDatabase);
-        Integer doctorId = doctorDatabase.add(doctor);
-
+    public void testCanSignInValidLoginDetails(){
         assertTrue("canSignIn should return true if given a username and password to an account in the " +
                 "database", doctorManager.canSignIn("jeff", "123"));
     }
+
+    /**
+     * Tests the doctor manager's method that checks if a doctor can sign in using invalid login details.
+     */
     @Test(timeout = 1000)
-    public void testCanSignInInvalid(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Doctor> doctorDatabase = originalDatabase.getDoctorDatabase();
-
-        Doctor doctor = new
-                Doctor("jeff", "123", 123456789);
-
-        DoctorManager doctorManager = new DoctorManager(originalDatabase);
-        Integer doctorId = doctorDatabase.add(doctor);
-
+    public void testCanSignInInvalidLoginDetails(){
         assertFalse("canSignIn should return false if given a username and password not linked to an account" +
                 "in the database", doctorManager.canSignIn("jim", "password"));
     }
+
+    /**
+     * Tests the doctor manager's method that returns a doctor's data bundle using valid login details.
+     */
     @Test(timeout = 1000)
     public void testSignInExistingAccount(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Doctor> doctorDatabase = originalDatabase.getDoctorDatabase();
-
-        Doctor doctor = new
-                Doctor("jeff", "123", 123456789);
-
-        DoctorManager doctorManager = new DoctorManager(originalDatabase);
-        Integer doctorId = doctorDatabase.add(doctor);
-        DoctorData doctorData = doctorManager.getUserData(doctor.getUsername());
+        DoctorData loadedDoctorData = doctorManager.getUserData(doctorData.getUsername());
 
         assertEquals("A correct account detail sign in should return the respective doctorData",
-                doctorManager.signIn(doctor.getUsername(), "123").getId(), doctorData.getId());
+                doctorManager.signIn(doctorData.getUsername(), "123").getId(), loadedDoctorData.getId());
     }
 
+    /**
+     * Tests the doctor manager's method that returns a doctor's data bundle using invalid login details.
+     */
     @Test(timeout = 1000)
     public void testSignInNonExistingAccount(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Doctor> doctorDatabase = originalDatabase.getDoctorDatabase();
-
-        Doctor doctor = new
-                Doctor("jeff", "123", 123456789);
-
-        DoctorManager doctorManager = new DoctorManager(originalDatabase);
-        Integer doctorId = doctorDatabase.add(doctor);
-        DoctorData doctorData = doctorManager.getUserData(doctor.getUsername());
-
         assertNull("an incorrect account detail sign in should return null", doctorManager.signIn("jim",
                 "password"));
     }
+
+    /**
+     * Deletes the temporary database folder used to store the database for tests after tests are done.
+     */
     @After
     public void after() {
         DeleteUtils.deleteDirectory(new File(databaseFolder.toString()));

--- a/test/DoctorManagerTests.java
+++ b/test/DoctorManagerTests.java
@@ -43,10 +43,10 @@ public class DoctorManagerTests {
     }
 
     /**
-     * Tests the doctor manager's method that creates a new doctor data bundle with a non-existing username.
+     * Tests createDoctor by creating a doctor in the database using a valid and unused username.
      */
     @Test(timeout = 1000)
-    public void testCreateDoctorValidUsername() {
+    public void testCreateDoctorValidUnused() {
         /* Testing if the return doctor data is valid by testing if the fields of are equal to the parameters of
         createDoctor */
         assertEquals("The created doctor data should have the same name as the parameters of " +
@@ -63,12 +63,22 @@ public class DoctorManagerTests {
     }
 
     /**
-     * Tests the doctor manager's method that creates a new doctor data bundle with an existing username.
+     * Tests createDoctor with a username that already exists in the database.
      */
     @Test(timeout = 1000)
-    public void testCreateDoctorInvalidUsername() {
+    public void testCreateDoctorExistingUsername() {
         assertNull("creating a user with the same name and password already existing in the database " +
                 "should return null", doctorManager.createDoctor(username, password));
+    }
+
+    /**
+     * Tests createDoctor with a format that does pass the regex check.
+     */
+    @Test(timeout = 1000)
+    public void testCreateDoctorInvalidFormat() {
+        assertThrows("creating a user with a non-alphanumeric username and a password shorter than 8 " +
+                        "characters will return an illegal argument exception", IllegalArgumentException.class,
+                () -> doctorManager.createDoctor("!!!", "123"));
     }
 
     /**

--- a/test/DoctorManagerTests.java
+++ b/test/DoctorManagerTests.java
@@ -28,6 +28,8 @@ public class DoctorManagerTests {
     private DataMapperGateway<Doctor> doctorDatabase;
     private DoctorManager doctorManager;
     private DoctorData doctorData;
+    private final String username = "mynamejeff";
+    private final String password = "123456789";
 
     /**
      * Initializes the variables used by all the tests before each unit test.
@@ -37,7 +39,7 @@ public class DoctorManagerTests {
         Database database = new Database(databaseFolder.toString());
         doctorDatabase = database.getDoctorDatabase();
         doctorManager = new DoctorManager(database);
-        doctorData = doctorManager.createDoctor("jeff", "123");
+        doctorData = doctorManager.createDoctor(username, password);
     }
 
     /**
@@ -48,16 +50,16 @@ public class DoctorManagerTests {
         /* Testing if the return doctor data is valid by testing if the fields of are equal to the parameters of
         createDoctor */
         assertEquals("The created doctor data should have the same name as the parameters of " +
-                "createDoctor method", doctorData.getUsername(), "jeff");
+                "createDoctor method", doctorData.getUsername(), username);
 
         Doctor loadedDoctor = doctorDatabase.get(doctorData.getId());
 
         /* Testing if the doctor object has been correctly added to the database by testing if the fields of the loaded
         doctor are equal to the parameters of createDoctor */
         assertEquals("Original doctor and loaded doctor should share the same unique username",
-                loadedDoctor.getUsername(), "jeff");
+                loadedDoctor.getUsername(), username);
         assertTrue("Original doctor and loaded doctor should share the same password",
-                loadedDoctor.comparePassword("123"));
+                loadedDoctor.comparePassword(password));
     }
 
     /**
@@ -66,7 +68,7 @@ public class DoctorManagerTests {
     @Test(timeout = 1000)
     public void testCreateDoctorInvalidUsername() {
         assertNull("creating a user with the same name and password already existing in the database " +
-                "should return null", doctorManager.createDoctor("jeff", "123"));
+                "should return null", doctorManager.createDoctor(username, password));
     }
 
     /**
@@ -89,7 +91,7 @@ public class DoctorManagerTests {
      */
     @Test(timeout = 1000)
     public void testDeleteDoctorInvalidUsername() {
-        boolean deleteDoctorReturnValue = doctorManager.deleteUser("jim");
+        boolean deleteDoctorReturnValue = doctorManager.deleteUser("jimhalpert");
 
         assertFalse("The method should return false when the username does not exist", deleteDoctorReturnValue);
     }
@@ -117,7 +119,7 @@ public class DoctorManagerTests {
     @Test(timeout = 1000)
     public void getUserDataInvalidUsername() {
         assertNull("trying to get user data of a user that doesn't exist should return null",
-                doctorManager.getUserData("jim"));
+                doctorManager.getUserData("jimhalpert"));
 
     }
 
@@ -143,7 +145,7 @@ public class DoctorManagerTests {
     @Test(timeout = 1000)
     public void testChangeUserPassword() {
         assertTrue("The password should remain the same before the change ",
-                doctorDatabase.get(doctorData.getId()).comparePassword("123"));
+                doctorDatabase.get(doctorData.getId()).comparePassword(password));
 
         doctorManager.changeUserPassword(doctorData, "456");
 
@@ -167,7 +169,7 @@ public class DoctorManagerTests {
         assertEquals("Original doctor and loaded doctor should share the same contact information",
                 doctorData.getContactInfoId(), loadedDoctor.getContactInfoId());
         assertTrue("Original doctor and loaded doctor should share the same password",
-                loadedDoctor.comparePassword("123"));
+                loadedDoctor.comparePassword(password));
     }
 
     /**
@@ -188,7 +190,7 @@ public class DoctorManagerTests {
     public void testUserDoesNotExist(){
         assertFalse("DoesUserExist should return false if there is no account stored in the database with the" +
                         "inputted username",
-                doctorManager.doesUserExist("jim"));
+                doctorManager.doesUserExist("jimhalpert"));
     }
 
     /**
@@ -197,7 +199,7 @@ public class DoctorManagerTests {
     @Test(timeout = 1000)
     public void testCanSignInValidLoginDetails(){
         assertTrue("canSignIn should return true if given a username and password to an account in the " +
-                "database", doctorManager.canSignIn("jeff", "123"));
+                "database", doctorManager.canSignIn(username, password));
     }
 
     /**
@@ -206,7 +208,7 @@ public class DoctorManagerTests {
     @Test(timeout = 1000)
     public void testCanSignInInvalidLoginDetails(){
         assertFalse("canSignIn should return false if given a username and password not linked to an account" +
-                "in the database", doctorManager.canSignIn("jim", "password"));
+                "in the database", doctorManager.canSignIn("jimhalpert", "password"));
     }
 
     /**
@@ -217,7 +219,7 @@ public class DoctorManagerTests {
         DoctorData loadedDoctorData = doctorManager.getUserData(doctorData.getUsername());
 
         assertEquals("A correct account detail sign in should return the respective doctorData",
-                doctorManager.signIn(doctorData.getUsername(), "123").getId(), loadedDoctorData.getId());
+                doctorManager.signIn(doctorData.getUsername(), password).getId(), loadedDoctorData.getId());
     }
 
     /**
@@ -225,8 +227,8 @@ public class DoctorManagerTests {
      */
     @Test(timeout = 1000)
     public void testSignInNonExistingAccount(){
-        assertNull("an incorrect account detail sign in should return null", doctorManager.signIn("jim",
-                "password"));
+        assertNull("an incorrect account detail sign in should return null", doctorManager.signIn(
+                "jimhalpert", "password"));
     }
 
     /**

--- a/test/LogManagerTests.java
+++ b/test/LogManagerTests.java
@@ -10,6 +10,9 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.stream.Collectors;
 
+/**
+ * Class of unit tests for LogManager use case class.
+ */
 public class LogManagerTests {
 
     /**

--- a/test/LogManagerTests.java
+++ b/test/LogManagerTests.java
@@ -2,10 +2,7 @@ import dataBundles.LogData;
 import dataBundles.PatientData;
 import database.Database;
 import entities.Patient;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.rules.TemporaryFolder;
 import useCases.LogManager;
 import utilities.DeleteUtils;
@@ -15,27 +12,44 @@ import java.util.stream.Collectors;
 
 public class LogManagerTests {
 
+    /**
+     * The variable representing the temporary folder where the databases used in these tests are stored until it is
+     * deleted after the tests.
+     */
     @Rule
     public TemporaryFolder databaseFolder = new TemporaryFolder();
-    @Test
-    public void testAddingNewLog(){
-        Database database = new Database(databaseFolder.toString());
-        Patient patient = new Patient("dan","dervi", 1);
-        Integer id = database.getPatientDatabase().add(patient);
-        LogManager logManager = new LogManager(database);
-        LogData logData = logManager.addLog("testing123", id);
-        Assert.assertEquals("Make sure that the right log is returned to the user", logData.getId(), id);
-        Assert.assertNotNull("Make sure that log actually exists in the database", database.getLogDatabase().get(id));
+    private Database database;
+    private Patient patient;
+    private Integer id;
+    private LogManager logManager;
+
+    /**
+     * Initializes the variables used by all the tests before each unit test.
+     */
+    @Before
+    public void before() {
+        database = new Database(databaseFolder.toString());
+        patient = new Patient("dan","dervi", 1);
+        id = database.getPatientDatabase().add(patient);
+        logManager = new LogManager(database);
     }
 
+    /**
+     * Tests the log manager method that adds a log to a user's logs.
+     */
     @Test
-    public void testGettingUserLogs(){
-        Database database = new Database(databaseFolder.toString());
-        Patient patient = new Patient("dan","dervi", 1);
-        Integer id = database.getPatientDatabase().add(patient);
-        LogManager logManager = new LogManager(database);
+    public void testAddingNewLog() {
+        LogData logData = logManager.addLog("testing123", id);
+        Assert.assertEquals("Make sure that the right log is returned to the user", logData.getId(), id);
+        Assert.assertNotNull("Make sure that log actually exists in the database",
+                database.getLogDatabase().get(id));
+    }
 
-
+    /**
+     * Tests the log manager getter method that returns a user's logs with an existing user.
+     */
+    @Test
+    public void testGettingExistingUserLogs() {
         LogData logA = logManager.addLog("testing1", id);
         LogData logB = logManager.addLog("testing2", id);
         LogData logC = logManager.addLog("testing3", id);
@@ -63,24 +77,28 @@ public class LogManagerTests {
         Assert.assertEquals("Make sure there are only 3 logs in the arraylist. When paired with the other" +
                 "assert statements, the arraylist only consists of logA, logB, logC", 3, logArrayList.size());
     }
-    @Test
-    public void testGettingNonExistentUserLogs(){
-        Database database = new Database(databaseFolder.toString());
-        Patient patient = new Patient("dan","dervi", 1);
-        LogManager logManager = new LogManager(database);
 
+    /**
+     * Tests the log manager getter method that returns a user's logs with a non-existent user.
+     */
+    @Test
+    public void testGettingNonExistentUserLogs() {
         logManager.addLog("testing1", 1);
         logManager.addLog("testing2", 1);
         logManager.addLog("testing3", 1);
         System.out.println(database.getLogDatabase());
 
         ArrayList<LogData> logArrayList = logManager.getUserLogs(new PatientData(patient));
-        Assert.assertTrue("Since the user doesn't exist, we should get an empty arraylist", logArrayList.isEmpty());
+        Assert.assertTrue("Since the user doesn't exist, we should get an empty arraylist",
+                logArrayList.isEmpty());
     }
 
-
+    /**
+     * Deletes the temporary database folder used to store the database for tests after tests are done.
+     */
     @After
     public void after() {
         DeleteUtils.deleteDirectory(new File(databaseFolder.toString()));
     }
+
 }

--- a/test/LogManagerTests.java
+++ b/test/LogManagerTests.java
@@ -32,7 +32,7 @@ public class LogManagerTests {
     @Before
     public void before() {
         database = new Database(databaseFolder.toString());
-        patient = new Patient("dan","dervi", 1);
+        patient = new Patient("danieldervy","123456789", 1);
         id = database.getPatientDatabase().add(patient);
         logManager = new LogManager(database);
     }

--- a/test/PatientManagerTests.java
+++ b/test/PatientManagerTests.java
@@ -1,37 +1,37 @@
-import dataBundles.ContactData;
 import dataBundles.PatientData;
 import database.DataMapperGateway;
 import database.Database;
 import entities.Patient;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import useCases.PatientManager;
 import utilities.DeleteUtils;
 import java.io.File;
-import java.time.LocalDate;
 import static org.junit.Assert.*;
 
 public class PatientManagerTests {
+    Database originalDatabase;
+    DataMapperGateway<Patient> patientDatabase;
+    PatientManager patientManager;
+    Patient patient;
 
     @Rule
     public TemporaryFolder databaseFolder = new TemporaryFolder();
 
+    @Before
+    public void before(){
+        originalDatabase = new Database(databaseFolder.toString());
+        patientDatabase = originalDatabase.getPatientDatabase();
+        patientManager = new PatientManager(originalDatabase);
+        patient = new Patient("jeff", "123", 123456789);
+    }
     @Test(timeout = 1000)
     public void testCreatePatientValid() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Patient> patientDatabase = originalDatabase.getPatientDatabase();
-
         String username = "jeff";
         String password = "123";
-        LocalDate birthday = LocalDate.of(2022, 1, 1);
-        ContactData contactData = new ContactData("jeff", "jeff@gmail.com",
-                "12345678", "jeff street", birthday, "jim",
-                "jim@gmail.com", "87654321",
-                "father");
-
-        PatientManager patientManager = new PatientManager(originalDatabase);
 
         PatientData patientData = patientManager.createPatient(username, password);
 
@@ -51,20 +51,10 @@ public class PatientManagerTests {
     }
     @Test(timeout = 1000)
     public void testCreatePatientInvalid() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Patient> patientDatabase = originalDatabase.getPatientDatabase();
-
         String username = "jeff";
         String password = "123";
-        LocalDate birthday = LocalDate.of(2022, 1, 1);
-        ContactData contactData = new ContactData("jeff", "jeff@gmail.com",
-                "12345678", "jeff street", birthday, "jim",
-                "jim@gmail.com", "87654321",
-                "father");
 
-        PatientManager patientManager = new PatientManager(originalDatabase);
-
-        PatientData patientData = patientManager.createPatient(username, password);
+        patientManager.createPatient(username, password);
 
         assertNull("creating a user with the same name and password already existing in the database " +
                 "should return null", patientManager.createPatient(username, password));
@@ -72,14 +62,6 @@ public class PatientManagerTests {
 
     @Test(timeout = 1000)
     public void testDeletePatient() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Patient> patientDatabase = originalDatabase.getPatientDatabase();
-
-        Patient patient = new
-                Patient("jeff", "123", 123456789);
-
-        PatientManager patientManager = new PatientManager(originalDatabase);
-
         Integer patientID = patientDatabase.add(patient);
 
         assertNotNull("A patient object should be returned before it is deleted ",
@@ -92,15 +74,7 @@ public class PatientManagerTests {
     }
     @Test(timeout = 1000)
     public void getUserData() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Patient> patientDatabase = originalDatabase.getPatientDatabase();
-
-        Patient patient = new
-                Patient("jeff", "123", 123456789);
-
-        PatientManager patientManager = new PatientManager(originalDatabase);
-
-        Integer patientID = patientDatabase.add(patient);
+        patientDatabase.add(patient);
 
         PatientData patientData = patientManager.getUserData(patient.getUsername());
 
@@ -117,23 +91,12 @@ public class PatientManagerTests {
     }
     @Test(timeout = 1000)
     public void getUserDataInvalid() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        PatientManager patientManager = new PatientManager(originalDatabase);
-
         assertNull("trying to get user data of a user that doesn't exist should return null",
                 patientManager.getUserData("jim"));
 
     }
     @Test(timeout = 1000)
     public void testDeletePatientByData() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Patient> patientDatabase = originalDatabase.getPatientDatabase();
-
-        Patient patient = new
-                Patient("jeff", "123", 123456789);
-
-        PatientManager patientManager = new PatientManager(originalDatabase);
-
         Integer patientID = patientDatabase.add(patient);
         PatientData userdata = patientManager.getUserData(patient.getUsername());
 
@@ -148,14 +111,6 @@ public class PatientManagerTests {
 
     @Test(timeout = 1000)
     public void testChangeUserPassword() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Patient> patientDatabase = originalDatabase.getPatientDatabase();
-
-        Patient patient = new
-                Patient("jeff", "123", 123456789);
-
-        PatientManager patientManager = new PatientManager(originalDatabase);
-
         Integer patientID = patientDatabase.add(patient);
         PatientData patientData = new PatientData(patient);
 
@@ -171,13 +126,7 @@ public class PatientManagerTests {
 
     @Test(timeout = 1000)
     public void testGetPatient() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Patient> patientDatabase = originalDatabase.getPatientDatabase();
-
-        Patient originalPatient = new
-                Patient("jeff", "123", 123456789);
-
-        PatientManager patientManager = new PatientManager(originalDatabase);
+        Patient originalPatient = patient;
 
         Integer patientID = patientDatabase.add(originalPatient);
 
@@ -199,13 +148,6 @@ public class PatientManagerTests {
 
     @Test(timeout = 1000)
     public void testDoesUserExist(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Patient> patientDatabase = originalDatabase.getPatientDatabase();
-
-        Patient patient = new
-                Patient("jeff", "123", 123456789);
-
-        PatientManager patientManager = new PatientManager(originalDatabase);
         Integer patientId = patientDatabase.add(patient);
 
         assertNotNull("A patient object should be returned when added to the database",
@@ -215,14 +157,7 @@ public class PatientManagerTests {
     }
     @Test(timeout = 1000)
     public void testUserDoesNotExist(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Patient> patientDatabase = originalDatabase.getPatientDatabase();
-
-        Patient patient = new
-                Patient("jeff", "123", 123456789);
-
-        PatientManager patientManager = new PatientManager(originalDatabase);
-        Integer patientId = patientDatabase.add(patient);
+        patientDatabase.add(patient);
 
         assertFalse("DoesUserExist should return false if there is no account stored in the database with the" +
                         "inputted username",
@@ -230,42 +165,21 @@ public class PatientManagerTests {
     }
     @Test(timeout = 1000)
     public void testCanSignInValid(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Patient> patientDatabase = originalDatabase.getPatientDatabase();
-
-        Patient patient = new
-                Patient("jeff", "123", 123456789);
-
-        PatientManager patientManager = new PatientManager(originalDatabase);
-        Integer patientId = patientDatabase.add(patient);
+        patientDatabase.add(patient);
 
         assertTrue("canSignIn should return true if given a username and password to an account in the " +
                 "database", patientManager.canSignIn("jeff", "123"));
     }
     @Test(timeout = 1000)
     public void testCanSignInInvalid(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Patient> patientDatabase = originalDatabase.getPatientDatabase();
-
-        Patient patient = new
-                Patient("jeff", "123", 123456789);
-
-        PatientManager patientManager = new PatientManager(originalDatabase);
-        Integer patientId = patientDatabase.add(patient);
+        patientDatabase.add(patient);
 
         assertFalse("canSignIn should return false if given a username and password not linked to an account" +
                 "in the database", patientManager.canSignIn("jim", "password"));
     }
     @Test(timeout = 1000)
     public void testSignInExistingAccount(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Patient> patientDatabase = originalDatabase.getPatientDatabase();
-
-        Patient patient = new
-                Patient("jeff", "123", 123456789);
-
-        PatientManager patientManager = new PatientManager(originalDatabase);
-        Integer patientId = patientDatabase.add(patient);
+        patientDatabase.add(patient);
         PatientData patientData = patientManager.getUserData(patient.getUsername());
 
         assertEquals("A correct account detail sign in should return the respective patientData",
@@ -274,15 +188,8 @@ public class PatientManagerTests {
 
     @Test(timeout = 1000)
     public void testSignInNonExistingAccount(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Patient> patientDatabase = originalDatabase.getPatientDatabase();
-
-        Patient patient = new
-                Patient("jeff", "123", 123456789);
-
-        PatientManager patientManager = new PatientManager(originalDatabase);
-        Integer patientId = patientDatabase.add(patient);
-        PatientData patientData = patientManager.getUserData(patient.getUsername());
+        patientDatabase.add(patient);
+        patientManager.getUserData(patient.getUsername());
 
         assertNull("an incorrect account detail sign in should return null", patientManager.signIn("jim",
                 "password"));

--- a/test/PatientManagerTests.java
+++ b/test/PatientManagerTests.java
@@ -26,6 +26,8 @@ public class PatientManagerTests {
     private DataMapperGateway<Patient> patientDatabase;
     private PatientManager patientManager;
     private PatientData patientData;
+    private final String username = "mynamejeff";
+    private final String password = "123456789";
 
     /**
      * Initializes the variables used by all the tests before each unit test.
@@ -35,7 +37,7 @@ public class PatientManagerTests {
         Database originalDatabase = new Database(databaseFolder.toString());
         patientDatabase = originalDatabase.getPatientDatabase();
         patientManager = new PatientManager(originalDatabase);
-        patientData = patientManager.createPatient("jeff", "123");
+        patientData = patientManager.createPatient(username, password);
     }
 
     /**
@@ -47,16 +49,16 @@ public class PatientManagerTests {
         /* Testing if the return patient data is valid by testing if the fields of are equal to the parameters of
         createPatient */
         assertEquals("The created patient data should have the same name as the parameters of " +
-                "createPatient method", patientData.getUsername(), "jeff");
+                "createPatient method", patientData.getUsername(), username);
 
         Patient loadedPatient = patientDatabase.get(patientData.getId());
 
         /* Testing if the patient object has been correctly added to the database by testing if the fields of the loaded
         patient are equal to the parameters of createPatient */
         assertEquals("Original patient and loaded patient should share the same unique username",
-                loadedPatient.getUsername(), "jeff");
+                loadedPatient.getUsername(), username);
         assertTrue("Original patient and loaded patient should share the same password",
-                loadedPatient.comparePassword("123"));
+                loadedPatient.comparePassword(password));
     }
 
     /**
@@ -65,7 +67,7 @@ public class PatientManagerTests {
     @Test(timeout = 1000)
     public void testCreatePatientInvalid() {
         assertNull("creating a user with the same name and password already existing in the database " +
-                "should return null", patientManager.createPatient("jeff", "123"));
+                "should return null", patientManager.createPatient(username, password));
     }
 
     /**
@@ -106,7 +108,7 @@ public class PatientManagerTests {
     @Test(timeout = 1000)
     public void getUserDataInvalid() {
         assertNull("trying to get user data of a user that doesn't exist should return null",
-                patientManager.getUserData("jim"));
+                patientManager.getUserData("jimhalpert"));
 
     }
 
@@ -130,7 +132,7 @@ public class PatientManagerTests {
     @Test(timeout = 1000)
     public void testChangeUserPassword() {
         assertTrue("The password should remain the same before the change ",
-                patientDatabase.get(patientData.getId()).comparePassword("123"));
+                patientDatabase.get(patientData.getId()).comparePassword(password));
 
         patientManager.changeUserPassword(patientData, "456");
 
@@ -155,7 +157,7 @@ public class PatientManagerTests {
         assertEquals("Original patient and loaded patient should share the same contact information",
                 patientData.getContactInfoId(), loadedPatient.getContactInfoId());
         assertTrue("Original patient and loaded patient should share the same password",
-                loadedPatient.comparePassword("123"));
+                loadedPatient.comparePassword(password));
     }
 
     /**
@@ -175,7 +177,7 @@ public class PatientManagerTests {
     @Test(timeout = 1000)
     public void testUserDoesNotExist(){
         assertFalse("DoesUserExist should return false if there is no account stored in the database with the" +
-                        "inputted username", patientManager.doesUserExist("jim"));
+                        "inputted username", patientManager.doesUserExist("jimhalpert"));
     }
 
     /**
@@ -184,7 +186,7 @@ public class PatientManagerTests {
     @Test(timeout = 1000)
     public void testCanSignInValid(){
         assertTrue("canSignIn should return true if given a username and password to an account in the " +
-                "database", patientManager.canSignIn("jeff", "123"));
+                "database", patientManager.canSignIn(username, password));
     }
 
     /**
@@ -193,7 +195,7 @@ public class PatientManagerTests {
     @Test(timeout = 1000)
     public void testCanSignInInvalid(){
         assertFalse("canSignIn should return false if given a username and password not linked to an account" +
-                "in the database", patientManager.canSignIn("jim", "password"));
+                "in the database", patientManager.canSignIn("jimhalpert", "password"));
     }
 
     /**
@@ -204,7 +206,7 @@ public class PatientManagerTests {
         PatientData loadedPatientData = patientManager.getUserData(patientData.getUsername());
 
         assertEquals("A correct account detail sign in should return the respective patientData",
-                patientManager.signIn(loadedPatientData.getUsername(), "123").getId(),
+                patientManager.signIn(loadedPatientData.getUsername(), password).getId(),
                 patientData.getId());
     }
 
@@ -213,8 +215,8 @@ public class PatientManagerTests {
      */
     @Test(timeout = 1000)
     public void testSignInNonExistingAccount(){
-        assertNull("an incorrect account detail sign in should return null", patientManager.signIn("jim",
-                "password"));
+        assertNull("an incorrect account detail sign in should return null", patientManager.signIn(
+                "jimhalpert", "password"));
     }
 
     /**

--- a/test/PatientManagerTests.java
+++ b/test/PatientManagerTests.java
@@ -16,10 +16,6 @@ import static org.junit.Assert.*;
  * Class of unit tests for LogManager use case class.
  */
 public class PatientManagerTests {
-    Database originalDatabase;
-    DataMapperGateway<Patient> patientDatabase;
-    PatientManager patientManager;
-    PatientData patientData;
 
     /**
      * The variable representing the temporary folder where the databases used in these tests are stored until it is
@@ -27,13 +23,16 @@ public class PatientManagerTests {
      */
     @Rule
     public TemporaryFolder databaseFolder = new TemporaryFolder();
+    private DataMapperGateway<Patient> patientDatabase;
+    private PatientManager patientManager;
+    private PatientData patientData;
 
     /**
      * Initializes the variables used by all the tests before each unit test.
      */
     @Before
     public void before(){
-        originalDatabase = new Database(databaseFolder.toString());
+        Database originalDatabase = new Database(databaseFolder.toString());
         patientDatabase = originalDatabase.getPatientDatabase();
         patientManager = new PatientManager(originalDatabase);
         patientData = patientManager.createPatient("jeff", "123");

--- a/test/PatientManagerTests.java
+++ b/test/PatientManagerTests.java
@@ -13,7 +13,7 @@ import java.io.File;
 import static org.junit.Assert.*;
 
 /**
- * Class of unit tests for LogManager use case class.
+ * Class of unit tests for PatientManager use case class.
  */
 public class PatientManagerTests {
 
@@ -175,8 +175,7 @@ public class PatientManagerTests {
     @Test(timeout = 1000)
     public void testUserDoesNotExist(){
         assertFalse("DoesUserExist should return false if there is no account stored in the database with the" +
-                        "inputted username",
-                patientManager.doesUserExist("jim"));
+                        "inputted username", patientManager.doesUserExist("jim"));
     }
 
     /**

--- a/test/PatientManagerTests.java
+++ b/test/PatientManagerTests.java
@@ -41,11 +41,10 @@ public class PatientManagerTests {
     }
 
     /**
-     * Tests createPatient by ensuring that the values of the patient stored in the database are the same as the
-     * PatientData returned from the function.
+     * Tests createPatient by creating an patient in the database using a valid and unused username.
      */
     @Test(timeout = 1000)
-    public void testCreatePatientValid() {
+    public void testCreatePatientValidUnused() {
         /* Testing if the return patient data is valid by testing if the fields of are equal to the parameters of
         createPatient */
         assertEquals("The created patient data should have the same name as the parameters of " +
@@ -62,12 +61,22 @@ public class PatientManagerTests {
     }
 
     /**
-     * Tests create patient with an invalid username and password that already exist in the database.
+     * Tests createPatient with a username that already exists in the database.
      */
     @Test(timeout = 1000)
-    public void testCreatePatientInvalid() {
+    public void testCreatePatientExistingUsername() {
         assertNull("creating a user with the same name and password already existing in the database " +
                 "should return null", patientManager.createPatient(username, password));
+    }
+
+    /**
+     * Tests createPatient with a format that does pass the regex check.
+     */
+    @Test(timeout = 1000)
+    public void testCreatePatientInvalidFormat() {
+        assertThrows("creating a user with a non-alphanumeric username and a password shorter than 8 " +
+                        "characters will return an illegal argument exception", IllegalArgumentException.class,
+                () -> patientManager.createPatient("!!!", "123"));
     }
 
     /**

--- a/test/PatientManagerTests.java
+++ b/test/PatientManagerTests.java
@@ -74,9 +74,15 @@ public class PatientManagerTests {
      */
     @Test(timeout = 1000)
     public void testCreatePatientInvalidFormat() {
-        assertThrows("creating a user with a non-alphanumeric username and a password shorter than 8 " +
-                        "characters will return an illegal argument exception", IllegalArgumentException.class,
-                () -> patientManager.createPatient("!!!", "123"));
+        assertThrows("creating a user with a non-alphanumeric username characters will return an illegal " +
+                        "argument exception", IllegalArgumentException.class,
+                () -> patientManager.createPatient("newuser!", "123456789"));
+        assertThrows("creating a user with a username shorter than 6 characters will return an illegal " +
+                        "argument exception", IllegalArgumentException.class,
+                () -> patientManager.createPatient("newu", "123456789"));
+        assertThrows("creating a user with a password shorter than 8 characters will return an illegal " +
+                        "argument exception", IllegalArgumentException.class,
+                () -> patientManager.createPatient("newuser1", "1234567"));
     }
 
     /**

--- a/test/PatientManagerTests.java
+++ b/test/PatientManagerTests.java
@@ -12,15 +12,25 @@ import utilities.DeleteUtils;
 import java.io.File;
 import static org.junit.Assert.*;
 
+/**
+ *Tests for Patient Manager Class.
+ */
 public class PatientManagerTests {
     Database originalDatabase;
     DataMapperGateway<Patient> patientDatabase;
     PatientManager patientManager;
     Patient patient;
 
+    /**
+     * The variable representing the temporary folder where the databases used in these tests are stored until it is
+     * deleted after the tests.
+     */
     @Rule
     public TemporaryFolder databaseFolder = new TemporaryFolder();
 
+    /**
+     * Initializes the variables used by all the tests before each unit test.
+     */
     @Before
     public void before(){
         originalDatabase = new Database(databaseFolder.toString());
@@ -28,6 +38,11 @@ public class PatientManagerTests {
         patientManager = new PatientManager(originalDatabase);
         patient = new Patient("jeff", "123", 123456789);
     }
+
+    /**
+     * Tests createPatient by ensuring that the values of the patient stored in the database are the same as the
+     * PatientData returned from the function.
+     */
     @Test(timeout = 1000)
     public void testCreatePatientValid() {
         String username = "jeff";
@@ -49,6 +64,10 @@ public class PatientManagerTests {
         assertTrue("Original patient and loaded patient should share the same password",
                 loadedPatient.comparePassword(password));
     }
+
+    /**
+     * Tests create patient with an invalid username and password that already exist in the database.
+     */
     @Test(timeout = 1000)
     public void testCreatePatientInvalid() {
         String username = "jeff";
@@ -60,6 +79,9 @@ public class PatientManagerTests {
                 "should return null", patientManager.createPatient(username, password));
     }
 
+    /**
+     * Tests a valid use of deletePatient.
+     */
     @Test(timeout = 1000)
     public void testDeletePatient() {
         Integer patientID = patientDatabase.add(patient);
@@ -72,6 +94,11 @@ public class PatientManagerTests {
         assertNull("A patient object should not be returned after it is deleted ",
                 patientDatabase.get(patientID));
     }
+
+    /**
+     * Tests getUserData by ensuring that the values from the patient stored in the database are the same as the values
+     * stored in the patientData returned from the function.
+     */
     @Test(timeout = 1000)
     public void getUserData() {
         patientDatabase.add(patient);
@@ -89,12 +116,20 @@ public class PatientManagerTests {
         assertTrue("patient and patientData should share the same password",
                 patient.comparePassword("123"));
     }
+
+    /**
+     * Tests an invalid use of getUserData when a username that does not exist in the database is inputted.
+     */
     @Test(timeout = 1000)
     public void getUserDataInvalid() {
         assertNull("trying to get user data of a user that doesn't exist should return null",
                 patientManager.getUserData("jim"));
 
     }
+
+    /**
+     * Tests deleteUserByData but specifically with patient data.
+     */
     @Test(timeout = 1000)
     public void testDeletePatientByData() {
         Integer patientID = patientDatabase.add(patient);
@@ -109,6 +144,9 @@ public class PatientManagerTests {
                 patientDatabase.get(patientID));
     }
 
+    /**
+     * Tests changeUserPassword specifically with patient data.
+     */
     @Test(timeout = 1000)
     public void testChangeUserPassword() {
         Integer patientID = patientDatabase.add(patient);
@@ -124,6 +162,10 @@ public class PatientManagerTests {
                 patientDatabase.get(patientID).comparePassword("456"));
     }
 
+    /**
+     * Tests getUser but specifically with patient data, and ensure the patient stored in the database and the returned
+     * loadedPatient.
+     */
     @Test(timeout = 1000)
     public void testGetPatient() {
         Patient originalPatient = patient;
@@ -146,6 +188,9 @@ public class PatientManagerTests {
                 loadedPatient.comparePassword("123"));
     }
 
+    /**
+     * Tests doesUserExist with the patient username inputted.
+     */
     @Test(timeout = 1000)
     public void testDoesUserExist(){
         Integer patientId = patientDatabase.add(patient);
@@ -155,6 +200,10 @@ public class PatientManagerTests {
         assertTrue("DoesUserExist should return true since the patient is stored in the database",
                 patientManager.doesUserExist(patient.getUsername()));
     }
+
+    /**
+     * Tests does user exist with an invalid username inputted.
+     */
     @Test(timeout = 1000)
     public void testUserDoesNotExist(){
         patientDatabase.add(patient);
@@ -163,6 +212,10 @@ public class PatientManagerTests {
                         "inputted username",
                 patientManager.doesUserExist("jim"));
     }
+
+    /**
+     * Tests a valid use of canSignIn with a patient's username and password.
+     */
     @Test(timeout = 1000)
     public void testCanSignInValid(){
         patientDatabase.add(patient);
@@ -170,6 +223,10 @@ public class PatientManagerTests {
         assertTrue("canSignIn should return true if given a username and password to an account in the " +
                 "database", patientManager.canSignIn("jeff", "123"));
     }
+
+    /**
+     * Tests an invalid use of canSignIn with a patient's username and password that does not exist in the database.
+     */
     @Test(timeout = 1000)
     public void testCanSignInInvalid(){
         patientDatabase.add(patient);
@@ -177,6 +234,10 @@ public class PatientManagerTests {
         assertFalse("canSignIn should return false if given a username and password not linked to an account" +
                 "in the database", patientManager.canSignIn("jim", "password"));
     }
+
+    /**
+     * Tests signIn with an existing patient account.
+     */
     @Test(timeout = 1000)
     public void testSignInExistingAccount(){
         patientDatabase.add(patient);
@@ -186,6 +247,9 @@ public class PatientManagerTests {
                 patientManager.signIn(patient.getUsername(), "123").getId(), patientData.getId());
     }
 
+    /**
+     * Tests an invalid use of signIn with a non-existing account.
+     */
     @Test(timeout = 1000)
     public void testSignInNonExistingAccount(){
         patientDatabase.add(patient);
@@ -195,6 +259,9 @@ public class PatientManagerTests {
                 "password"));
     }
 
+    /**
+     * Deletes the temporary database folder used to store the database for tests after tests are done.
+     */
     @After
     public void after() {
         DeleteUtils.deleteDirectory(new File(databaseFolder.toString()));

--- a/test/PatientManagerTests.java
+++ b/test/PatientManagerTests.java
@@ -19,7 +19,7 @@ public class PatientManagerTests {
     Database originalDatabase;
     DataMapperGateway<Patient> patientDatabase;
     PatientManager patientManager;
-    Patient patient;
+    PatientData patientData;
 
     /**
      * The variable representing the temporary folder where the databases used in these tests are stored until it is
@@ -36,7 +36,7 @@ public class PatientManagerTests {
         originalDatabase = new Database(databaseFolder.toString());
         patientDatabase = originalDatabase.getPatientDatabase();
         patientManager = new PatientManager(originalDatabase);
-        patient = new Patient("jeff", "123", 123456789);
+        patientData = patientManager.createPatient("jeff", "123");
     }
 
     /**
@@ -45,24 +45,19 @@ public class PatientManagerTests {
      */
     @Test(timeout = 1000)
     public void testCreatePatientValid() {
-        String username = "jeff";
-        String password = "123";
-
-        PatientData patientData = patientManager.createPatient(username, password);
-
         /* Testing if the return patient data is valid by testing if the fields of are equal to the parameters of
         createPatient */
         assertEquals("The created patient data should have the same name as the parameters of " +
-                "createPatient method", patientData.getUsername(), username);
+                "createPatient method", patientData.getUsername(), "jeff");
 
         Patient loadedPatient = patientDatabase.get(patientData.getId());
 
         /* Testing if the patient object has been correctly added to the database by testing if the fields of the loaded
         patient are equal to the parameters of createPatient */
         assertEquals("Original patient and loaded patient should share the same unique username",
-                loadedPatient.getUsername(), username);
+                loadedPatient.getUsername(), "jeff");
         assertTrue("Original patient and loaded patient should share the same password",
-                loadedPatient.comparePassword(password));
+                loadedPatient.comparePassword("123"));
     }
 
     /**
@@ -70,13 +65,8 @@ public class PatientManagerTests {
      */
     @Test(timeout = 1000)
     public void testCreatePatientInvalid() {
-        String username = "jeff";
-        String password = "123";
-
-        patientManager.createPatient(username, password);
-
         assertNull("creating a user with the same name and password already existing in the database " +
-                "should return null", patientManager.createPatient(username, password));
+                "should return null", patientManager.createPatient("jeff", "123"));
     }
 
     /**
@@ -84,15 +74,13 @@ public class PatientManagerTests {
      */
     @Test(timeout = 1000)
     public void testDeletePatient() {
-        Integer patientID = patientDatabase.add(patient);
-
         assertNotNull("A patient object should be returned before it is deleted ",
-                patientDatabase.get(patientID));
+                patientDatabase.get(patientData.getId()));
 
-        patientManager.deleteUser(patient.getUsername());
+        patientManager.deleteUser(patientData.getUsername());
 
         assertNull("A patient object should not be returned after it is deleted ",
-                patientDatabase.get(patientID));
+                patientDatabase.get(patientData.getId()));
     }
 
     /**
@@ -101,20 +89,16 @@ public class PatientManagerTests {
      */
     @Test(timeout = 1000)
     public void getUserData() {
-        patientDatabase.add(patient);
-
-        PatientData patientData = patientManager.getUserData(patient.getUsername());
+        PatientData loadedPatientData = patientManager.getUserData(patientData.getUsername());
 
         /* Testing if the patientData and the original patient are equal by testing whether all the fields of both
         objects are equal */
         assertEquals("patient and patientData should share the same Id",
-                patient.getId(), patientData.getId());
+                patientData.getId(), loadedPatientData.getId());
         assertEquals("patient and patientData should share the same unique username",
-                patient.getUsername(), patientData.getUsername());
+                patientData.getUsername(), loadedPatientData.getUsername());
         assertEquals("patient and patientData should share the same contact information",
-                patient.getContactInfoId(), patientData.getContactInfoId());
-        assertTrue("patient and patientData should share the same password",
-                patient.comparePassword("123"));
+                patientData.getContactInfoId(), loadedPatientData.getContactInfoId());
     }
 
     /**
@@ -132,16 +116,13 @@ public class PatientManagerTests {
      */
     @Test(timeout = 1000)
     public void testDeletePatientByData() {
-        Integer patientID = patientDatabase.add(patient);
-        PatientData userdata = patientManager.getUserData(patient.getUsername());
-
         assertNotNull("A patient object should be returned before it is deleted ",
-                patientDatabase.get(patientID));
+                patientDatabase.get(patientData.getId()));
 
-        patientManager.deleteUserByData(userdata);
+        patientManager.deleteUserByData(patientData);
 
         assertNull("A patient object should not be returned after it is deleted by data",
-                patientDatabase.get(patientID));
+                patientDatabase.get(patientData.getId()));
     }
 
     /**
@@ -149,17 +130,14 @@ public class PatientManagerTests {
      */
     @Test(timeout = 1000)
     public void testChangeUserPassword() {
-        Integer patientID = patientDatabase.add(patient);
-        PatientData patientData = new PatientData(patient);
-
         assertTrue("The password should remain the same before the change ",
-                patientDatabase.get(patientID).comparePassword("123"));
+                patientDatabase.get(patientData.getId()).comparePassword("123"));
 
         patientManager.changeUserPassword(patientData, "456");
 
         assertTrue("The patient object should have the same password as we inputted into the parameters " +
                         "of the changeUserPassword method ",
-                patientDatabase.get(patientID).comparePassword("456"));
+                patientDatabase.get(patientData.getId()).comparePassword("456"));
     }
 
     /**
@@ -168,22 +146,15 @@ public class PatientManagerTests {
      */
     @Test(timeout = 1000)
     public void testGetPatient() {
-        Patient originalPatient = patient;
-
-        Integer patientID = patientDatabase.add(originalPatient);
-
-        assertEquals("Original patient should share the same ID from the database",
-                originalPatient.getId(), patientID);
-
-        Patient loadedPatient = patientDatabase.get(originalPatient.getId());
+        Patient loadedPatient = patientDatabase.get(patientData.getId());
         /* Testing if the loaded patient and the original patient are equal by testing whether all the fields of both
         objects are equal */
         assertEquals("Original patient and loaded patient should share the same Id",
-                originalPatient.getId(), loadedPatient.getId());
+                patientData.getId(), loadedPatient.getId());
         assertEquals("Original patient and loaded patient should share the same unique username",
-                originalPatient.getUsername(), loadedPatient.getUsername());
+                patientData.getUsername(), loadedPatient.getUsername());
         assertEquals("Original patient and loaded patient should share the same contact information",
-                originalPatient.getContactInfoId(), loadedPatient.getContactInfoId());
+                patientData.getContactInfoId(), loadedPatient.getContactInfoId());
         assertTrue("Original patient and loaded patient should share the same password",
                 loadedPatient.comparePassword("123"));
     }
@@ -193,12 +164,10 @@ public class PatientManagerTests {
      */
     @Test(timeout = 1000)
     public void testDoesUserExist(){
-        Integer patientId = patientDatabase.add(patient);
-
         assertNotNull("A patient object should be returned when added to the database",
-                patientDatabase.get(patientId));
+                patientDatabase.get(patientData.getId()));
         assertTrue("DoesUserExist should return true since the patient is stored in the database",
-                patientManager.doesUserExist(patient.getUsername()));
+                patientManager.doesUserExist(patientData.getUsername()));
     }
 
     /**
@@ -206,8 +175,6 @@ public class PatientManagerTests {
      */
     @Test(timeout = 1000)
     public void testUserDoesNotExist(){
-        patientDatabase.add(patient);
-
         assertFalse("DoesUserExist should return false if there is no account stored in the database with the" +
                         "inputted username",
                 patientManager.doesUserExist("jim"));
@@ -218,8 +185,6 @@ public class PatientManagerTests {
      */
     @Test(timeout = 1000)
     public void testCanSignInValid(){
-        patientDatabase.add(patient);
-
         assertTrue("canSignIn should return true if given a username and password to an account in the " +
                 "database", patientManager.canSignIn("jeff", "123"));
     }
@@ -229,8 +194,6 @@ public class PatientManagerTests {
      */
     @Test(timeout = 1000)
     public void testCanSignInInvalid(){
-        patientDatabase.add(patient);
-
         assertFalse("canSignIn should return false if given a username and password not linked to an account" +
                 "in the database", patientManager.canSignIn("jim", "password"));
     }
@@ -240,11 +203,11 @@ public class PatientManagerTests {
      */
     @Test(timeout = 1000)
     public void testSignInExistingAccount(){
-        patientDatabase.add(patient);
-        PatientData patientData = patientManager.getUserData(patient.getUsername());
+        PatientData loadedPatientData = patientManager.getUserData(patientData.getUsername());
 
         assertEquals("A correct account detail sign in should return the respective patientData",
-                patientManager.signIn(patient.getUsername(), "123").getId(), patientData.getId());
+                patientManager.signIn(loadedPatientData.getUsername(), "123").getId(),
+                patientData.getId());
     }
 
     /**
@@ -252,9 +215,6 @@ public class PatientManagerTests {
      */
     @Test(timeout = 1000)
     public void testSignInNonExistingAccount(){
-        patientDatabase.add(patient);
-        patientManager.getUserData(patient.getUsername());
-
         assertNull("an incorrect account detail sign in should return null", patientManager.signIn("jim",
                 "password"));
     }
@@ -266,4 +226,5 @@ public class PatientManagerTests {
     public void after() {
         DeleteUtils.deleteDirectory(new File(databaseFolder.toString()));
     }
+
 }

--- a/test/PatientManagerTests.java
+++ b/test/PatientManagerTests.java
@@ -13,7 +13,7 @@ import java.io.File;
 import static org.junit.Assert.*;
 
 /**
- *Tests for Patient Manager Class.
+ * Class of unit tests for LogManager use case class.
  */
 public class PatientManagerTests {
     Database originalDatabase;

--- a/test/PrescriptionManagerTests.java
+++ b/test/PrescriptionManagerTests.java
@@ -97,8 +97,8 @@ public class PrescriptionManagerTests {
         ArrayList<PrescriptionData> loadedPrescriptionList =
                 prescriptionManager.getAllActivePrescriptions(patientData);
 
-        assertTrue("Since there are no non expired prescriptions, the ArrayList should be empty",
-                loadedPrescriptionList.isEmpty());
+        assertEquals("Since there is only one non expired prescriptions, the ArrayList have a length of 1",
+                loadedPrescriptionList.size(), 1);
     }
 
     /**

--- a/test/PrescriptionManagerTests.java
+++ b/test/PrescriptionManagerTests.java
@@ -45,8 +45,8 @@ public class PrescriptionManagerTests {
     public void before(){
         originalDatabase = new Database(databaseFolder.toString());
         prescriptionDatabase = originalDatabase.getPrescriptionDatabase();
-        patientData = new PatientManager(originalDatabase).createPatient("test 4", "test4");
-        doctorData = new DoctorManager(originalDatabase).createDoctor("test 3", "test4");
+        patientData = new PatientManager(originalDatabase).createPatient("mynamejeff", "123456789");
+        doctorData = new DoctorManager(originalDatabase).createDoctor("mynamejim", "123456789");
         prescriptionManager = new PrescriptionManager(originalDatabase);
         LocalDate inactiveLocalExpiryDate = LocalDate.of(2020, 2, 2);
         LocalDate activeLocalExpiryDate = LocalDate.of(2099, 1, 1);

--- a/test/PrescriptionManagerTests.java
+++ b/test/PrescriptionManagerTests.java
@@ -25,8 +25,8 @@ import static org.junit.Assert.assertEquals;
 public class PrescriptionManagerTests {
     Database originalDatabase;
     DataMapperGateway<Prescription> prescriptionDatabase;
-    PatientData patient;
-    DoctorData doctor;
+    PatientData patientData;
+    DoctorData doctorData;
     PrescriptionManager prescriptionManager;
 
     /**
@@ -43,8 +43,8 @@ public class PrescriptionManagerTests {
     public void before(){
         originalDatabase = new Database(databaseFolder.toString());
         prescriptionDatabase = originalDatabase.getPrescriptionDatabase();
-        patient = new PatientManager(originalDatabase).createPatient("test 4", "test4");
-        doctor = new DoctorManager(originalDatabase).createDoctor("test 3", "test4");
+        patientData = new PatientManager(originalDatabase).createPatient("test 4", "test4");
+        doctorData = new DoctorManager(originalDatabase).createDoctor("test 3", "test4");
         prescriptionManager = new PrescriptionManager(originalDatabase);
     }
 
@@ -57,10 +57,10 @@ public class PrescriptionManagerTests {
         LocalDate localExpiryDate = LocalDate.of(2050, 7, 1);
 
         Prescription originalPrescription1 = new
-                Prescription("medicine", "healthy", patient.getId(), doctor.getId(), localExpiryDate);
+                Prescription("medicine", "healthy", patientData.getId(), doctorData.getId(), localExpiryDate);
         Prescription originalPrescription2 = new
-                Prescription("bad", "very unhealthy", patient.getId(),
-                doctor.getId(), localExpiryDate);
+                Prescription("bad", "very unhealthy", patientData.getId(),
+                doctorData.getId(), localExpiryDate);
 
         prescriptionDatabase.add(originalPrescription1);
         prescriptionDatabase.add(originalPrescription2);
@@ -68,7 +68,7 @@ public class PrescriptionManagerTests {
         PrescriptionData originalPrescriptionBundle1 = new PrescriptionData(originalPrescription1);
 
         ArrayList<PrescriptionData> loadedPrescriptionList =
-                prescriptionManager.getAllActivePrescriptions(patient);
+                prescriptionManager.getAllActivePrescriptions(patientData);
 
         PrescriptionData loadedPrescriptionData1 = loadedPrescriptionList.get(0);
 
@@ -100,17 +100,17 @@ public class PrescriptionManagerTests {
         LocalDate localExpiryDate = LocalDate.of(2021, 7, 1);
 
         Prescription originalPrescription1 = new
-                Prescription("medicine", "healthy", patient.getId(),
-                doctor.getId(), localExpiryDate);
+                Prescription("medicine", "healthy", patientData.getId(),
+                doctorData.getId(), localExpiryDate);
         Prescription originalPrescription2 = new
-                Prescription("bad", "very unhealthy", doctor.getId(),
-                doctor.getId(), localExpiryDate);
+                Prescription("bad", "very unhealthy", doctorData.getId(),
+                doctorData.getId(), localExpiryDate);
 
         prescriptionDatabase.add(originalPrescription1);
         prescriptionDatabase.add(originalPrescription2);
 
         ArrayList<PrescriptionData> loadedPrescriptionList =
-                prescriptionManager.getAllActivePrescriptions(patient);
+                prescriptionManager.getAllActivePrescriptions(patientData);
 
         assertTrue("Since there are no non expired prescriptions, the ArrayList should be empty",
                 loadedPrescriptionList.isEmpty());
@@ -125,17 +125,17 @@ public class PrescriptionManagerTests {
         LocalDate activeLocalExpiryDate = LocalDate.of(2050, 7, 1);
 
         Prescription originalPrescription1 = new
-                Prescription("medicine", "healthy", patient.getId(),
-                doctor.getId(), inactiveLocalExpiryDate);
+                Prescription("medicine", "healthy", patientData.getId(),
+                doctorData.getId(), inactiveLocalExpiryDate);
         Prescription originalPrescription2 = new
-                Prescription("bad", "very unhealthy", patient.getId(),
-                doctor.getId(), activeLocalExpiryDate);
+                Prescription("bad", "very unhealthy", patientData.getId(),
+                doctorData.getId(), activeLocalExpiryDate);
 
         prescriptionDatabase.add(originalPrescription1);
         prescriptionDatabase.add(originalPrescription2);
 
         ArrayList<PrescriptionData> loadedPrescriptionList =
-                prescriptionManager.getAllPrescriptions(patient);
+                prescriptionManager.getAllPrescriptions(patientData);
 
         assertEquals("The array list should have a length of 2 even though one of " +
                         "the prescriptions is expired", 2, loadedPrescriptionList.size());
@@ -151,8 +151,8 @@ public class PrescriptionManagerTests {
         String header = "medicine";
         String body = "healthy";
 
-        PrescriptionData prescriptionData = prescriptionManager.createPrescription(header, body, patient,
-                doctor, localExpiryDate);
+        PrescriptionData prescriptionData = prescriptionManager.createPrescription(header, body, patientData,
+                doctorData, localExpiryDate);
 
         /* testing if the created prescription data is valid by testing if its fields match with the parameters
         * of the createPrescription method */
@@ -161,9 +161,9 @@ public class PrescriptionManagerTests {
         assertEquals("The created prescription data should have the same body as the " +
                         "parameters of createPrescription method", prescriptionData.getBody(), body);
         assertEquals("The created prescription data should have the same patient ID noted as the " +
-                        "parameters of createPrescription method", prescriptionData.getPatientId(), patient.getId());
+                        "parameters of createPrescription method", prescriptionData.getPatientId(), patientData.getId());
         assertEquals("The created prescription data should have the same patient ID noted as the " +
-                "parameters of createPrescription method", prescriptionData.getDoctorId(), doctor.getId());
+                "parameters of createPrescription method", prescriptionData.getDoctorId(), doctorData.getId());
         assertEquals("Original prescription and loaded prescription have the same expiry date",
                 prescriptionData.getExpiryDate().compareTo(localExpiryDate), 0);
 
@@ -176,9 +176,9 @@ public class PrescriptionManagerTests {
         assertEquals("The loaded prescription object should have the same body as the " +
                 "parameters of createPrescription method", loadedPrescription.getBody(), body);
         assertEquals("The loaded prescription object should have the same patient ID noted as the " +
-                "parameters of createPrescription method", loadedPrescription.getPatientId(), patient.getId());
+                "parameters of createPrescription method", loadedPrescription.getPatientId(), patientData.getId());
         assertEquals("The loaded prescription object should have the same patient ID noted as the " +
-                "parameters of createPrescription method", prescriptionData.getDoctorId(), doctor.getId());
+                "parameters of createPrescription method", prescriptionData.getDoctorId(), doctorData.getId());
         assertEquals("The loaded prescription object should have the same expiry as the parameters of " +
                         "createPrescription method", prescriptionData.getExpiryDate().compareTo(localExpiryDate),
                 0);
@@ -193,25 +193,25 @@ public class PrescriptionManagerTests {
         LocalDate activeLocalExpiryDate = LocalDate.of(2050, 7, 1);
 
         Prescription originalPrescription1 = new
-                Prescription("medicine", "healthy", patient.getId(),
-                doctor.getId(), inactiveLocalExpiryDate);
+                Prescription("medicine", "healthy", patientData.getId(),
+                doctorData.getId(), inactiveLocalExpiryDate);
         Prescription originalPrescription2 = new
-                Prescription("bad", "very unhealthy", patient.getId(),
-                doctor.getId(), activeLocalExpiryDate);
+                Prescription("bad", "very unhealthy", patientData.getId(),
+                doctorData.getId(), activeLocalExpiryDate);
 
         prescriptionDatabase.add(originalPrescription1);
         prescriptionDatabase.add(originalPrescription2);
 
-        ArrayList<PrescriptionData> loadedPrescriptionList1 =
-                prescriptionManager.getAllPrescriptions(patient);
+        ArrayList<PrescriptionData> loadedPrescriptionDataList1 =
+                prescriptionManager.getAllPrescriptions(patientData);
 
         assertEquals("The array list should have a length of 2 before a prescription is removed ",
-                2, loadedPrescriptionList1.size());
+                2, loadedPrescriptionDataList1.size());
 
         prescriptionManager.removePrescription(new PrescriptionData(originalPrescription2));
 
         ArrayList<PrescriptionData> loadedPrescriptionList2 =
-                prescriptionManager.getAllPrescriptions(patient);
+                prescriptionManager.getAllPrescriptions(patientData);
 
         assertEquals("The array list should have a length of 1 after a prescription is removed ",
                 1, loadedPrescriptionList2.size());
@@ -219,7 +219,7 @@ public class PrescriptionManagerTests {
         prescriptionManager.removePrescription(new PrescriptionData(originalPrescription1));
 
         ArrayList<PrescriptionData> loadedPrescriptionList3 =
-                prescriptionManager.getAllPrescriptions(patient);
+                prescriptionManager.getAllPrescriptions(patientData);
 
         assertTrue("The array list should be empty after all prescriptions are removed",
                 loadedPrescriptionList3.isEmpty());
@@ -236,11 +236,11 @@ public class PrescriptionManagerTests {
         LocalDate activeLocalExpiryDate = LocalDate.of(2050, 7, 1);
 
         Prescription originalPrescription1 = new
-                Prescription("medicine", "healthy", patient.getId(),
-                doctor.getId(), inactiveLocalExpiryDate);
+                Prescription("medicine", "healthy", patientData.getId(),
+                doctorData.getId(), inactiveLocalExpiryDate);
         Prescription originalPrescription2 = new
-                Prescription("bad", "very unhealthy", patient.getId(),
-                doctor.getId(), activeLocalExpiryDate);
+                Prescription("bad", "very unhealthy", patientData.getId(),
+                doctorData.getId(), activeLocalExpiryDate);
 
         prescriptionDatabase.add(originalPrescription1);
         prescriptionDatabase.add(originalPrescription2);

--- a/test/PrescriptionManagerTests.java
+++ b/test/PrescriptionManagerTests.java
@@ -23,11 +23,6 @@ import static org.junit.Assert.assertEquals;
  * Tests for the PrescriptionManager class.
  */
 public class PrescriptionManagerTests {
-    Database originalDatabase;
-    DataMapperGateway<Prescription> prescriptionDatabase;
-    PatientData patient;
-    DoctorData doctor;
-    PrescriptionManager prescriptionManager;
 
     /**
      * The variable representing the temporary folder where the databases used in these tests are stored until it is
@@ -35,6 +30,14 @@ public class PrescriptionManagerTests {
      */
     @Rule
     public TemporaryFolder databaseFolder = new TemporaryFolder();
+    private Database originalDatabase;
+    private DataMapperGateway<Prescription> prescriptionDatabase;
+    private PatientData patientData;
+    private DoctorData doctorData;
+    private PrescriptionManager prescriptionManager;
+    private PrescriptionData inactivePrescriptionData;
+    private PrescriptionData activePrescriptionData;
+
 
     /**
      * Initializes the variables used by all the tests before each unit test.
@@ -43,9 +46,16 @@ public class PrescriptionManagerTests {
     public void before(){
         originalDatabase = new Database(databaseFolder.toString());
         prescriptionDatabase = originalDatabase.getPrescriptionDatabase();
-        patient = new PatientManager(originalDatabase).createPatient("test 4", "test4");
-        doctor = new DoctorManager(originalDatabase).createDoctor("test 3", "test4");
+        patientData = new PatientManager(originalDatabase).createPatient("test 4", "test4");
+        doctorData = new DoctorManager(originalDatabase).createDoctor("test 3", "test4");
         prescriptionManager = new PrescriptionManager(originalDatabase);
+        LocalDate inactiveLocalExpiryDate = LocalDate.of(2020, 2, 2);
+        LocalDate activeLocalExpiryDate = LocalDate.of(2099, 1, 1);
+        inactivePrescriptionData = prescriptionManager.createPrescription("medicine", "healthy",
+                patientData, doctorData, inactiveLocalExpiryDate);
+        activePrescriptionData = prescriptionManager.createPrescription("bad", "very unhealthy",
+                patientData, doctorData, activeLocalExpiryDate);
+
     }
 
     /**
@@ -54,41 +64,28 @@ public class PrescriptionManagerTests {
      */
     @Test(timeout = 1000)
     public void testGetPatientActivePrescriptionDataUsingActivePrescription() {
-        LocalDate localExpiryDate = LocalDate.of(2050, 7, 1);
-
-        Prescription originalPrescription1 = new
-                Prescription("medicine", "healthy", patient.getId(), doctor.getId(), localExpiryDate);
-        Prescription originalPrescription2 = new
-                Prescription("bad", "very unhealthy", patient.getId(),
-                doctor.getId(), localExpiryDate);
-
-        prescriptionDatabase.add(originalPrescription1);
-        prescriptionDatabase.add(originalPrescription2);
-
-        PrescriptionData originalPrescriptionBundle1 = new PrescriptionData(originalPrescription1);
-
         ArrayList<PrescriptionData> loadedPrescriptionList =
-                prescriptionManager.getAllActivePrescriptions(patient);
+                prescriptionManager.getAllActivePrescriptions(patientData);
 
-        PrescriptionData loadedPrescriptionData1 = loadedPrescriptionList.get(0);
+        PrescriptionData loadedPrescriptionData = loadedPrescriptionList.get(0);
 
         /* testing if the loaded prescription and the original prescription are equal by testing whether all
         the fields of both objects are equal */
         assertEquals("Original prescription and loaded prescription should share the same ID",
-                originalPrescriptionBundle1.getPrescriptionId(), loadedPrescriptionData1.getPrescriptionId());
+                activePrescriptionData.getPrescriptionId(), loadedPrescriptionData.getPrescriptionId());
         assertEquals("Original prescription and loaded prescription should be have been noted " +
-                "on the same date", originalPrescriptionBundle1.getDateNoted().compareTo(loadedPrescriptionData1.
+                "on the same date", activePrescriptionData.getDateNoted().compareTo(loadedPrescriptionData.
                 getDateNoted()), 0); // the compareTo function returns 0 when both dates are equal
         assertEquals("Original prescription and loaded prescription should share the same header",
-                originalPrescriptionBundle1.getHeader(), loadedPrescriptionData1.getHeader());
+                activePrescriptionData.getHeader(), loadedPrescriptionData.getHeader());
         assertEquals("Original prescription and loaded prescription should share the same body",
-                originalPrescriptionBundle1.getBody(), loadedPrescriptionData1.getBody());
+                activePrescriptionData.getBody(), loadedPrescriptionData.getBody());
         assertEquals("Original prescription and loaded prescription should share the same patient ID",
-                originalPrescriptionBundle1.getPatientId(), loadedPrescriptionData1.getPatientId());
+                activePrescriptionData.getPatientId(), loadedPrescriptionData.getPatientId());
         assertEquals("Original prescription and loaded prescription should share the same doctor ID",
-                originalPrescriptionBundle1.getDoctorId(), loadedPrescriptionData1.getDoctorId());
+                activePrescriptionData.getDoctorId(), loadedPrescriptionData.getDoctorId());
         assertEquals("Original prescription and loaded prescription have the same expiry date",
-                originalPrescriptionBundle1.getExpiryDate().compareTo(loadedPrescriptionData1.
+                activePrescriptionData.getExpiryDate().compareTo(loadedPrescriptionData.
                         getExpiryDate()), 0);
     }
     /**
@@ -97,20 +94,8 @@ public class PrescriptionManagerTests {
      */
     @Test(timeout = 1000)
     public void testGetPatientActivePrescriptionDataUsingInactivePrescription() {
-        LocalDate localExpiryDate = LocalDate.of(2021, 7, 1);
-
-        Prescription originalPrescription1 = new
-                Prescription("medicine", "healthy", patient.getId(),
-                doctor.getId(), localExpiryDate);
-        Prescription originalPrescription2 = new
-                Prescription("bad", "very unhealthy", doctor.getId(),
-                doctor.getId(), localExpiryDate);
-
-        prescriptionDatabase.add(originalPrescription1);
-        prescriptionDatabase.add(originalPrescription2);
-
         ArrayList<PrescriptionData> loadedPrescriptionList =
-                prescriptionManager.getAllActivePrescriptions(patient);
+                prescriptionManager.getAllActivePrescriptions(patientData);
 
         assertTrue("Since there are no non expired prescriptions, the ArrayList should be empty",
                 loadedPrescriptionList.isEmpty());
@@ -121,21 +106,8 @@ public class PrescriptionManagerTests {
      */
     @Test(timeout = 1000)
     public void testGetPatientAllPrescriptionData() {
-        LocalDate inactiveLocalExpiryDate = LocalDate.of(2021, 7, 1);
-        LocalDate activeLocalExpiryDate = LocalDate.of(2050, 7, 1);
-
-        Prescription originalPrescription1 = new
-                Prescription("medicine", "healthy", patient.getId(),
-                doctor.getId(), inactiveLocalExpiryDate);
-        Prescription originalPrescription2 = new
-                Prescription("bad", "very unhealthy", patient.getId(),
-                doctor.getId(), activeLocalExpiryDate);
-
-        prescriptionDatabase.add(originalPrescription1);
-        prescriptionDatabase.add(originalPrescription2);
-
         ArrayList<PrescriptionData> loadedPrescriptionList =
-                prescriptionManager.getAllPrescriptions(patient);
+                prescriptionManager.getAllPrescriptions(patientData);
 
         assertEquals("The array list should have a length of 2 even though one of " +
                         "the prescriptions is expired", 2, loadedPrescriptionList.size());
@@ -147,41 +119,37 @@ public class PrescriptionManagerTests {
      */
     @Test(timeout = 1000)
     public void testCreatePrescription() {
-        LocalDate localExpiryDate = LocalDate.of(2050, 7, 1);
-        String header = "medicine";
-        String body = "healthy";
-
-        PrescriptionData prescriptionData = prescriptionManager.createPrescription(header, body, patient,
-                doctor, localExpiryDate);
-
+        LocalDate activeLocalExpiryDate = LocalDate.of(2099, 1, 1);
         /* testing if the created prescription data is valid by testing if its fields match with the parameters
         * of the createPrescription method */
         assertEquals("The created prescription data should have the same header as the " +
-                        "parameters of createPrescription method", prescriptionData.getHeader(), header);
+                        "parameters of createPrescription method", activePrescriptionData.getHeader(), "bad");
         assertEquals("The created prescription data should have the same body as the " +
-                        "parameters of createPrescription method", prescriptionData.getBody(), body);
+                        "parameters of createPrescription method", activePrescriptionData.getBody(),
+                "very unhealthy");
         assertEquals("The created prescription data should have the same patient ID noted as the " +
-                        "parameters of createPrescription method", prescriptionData.getPatientId(), patient.getId());
+                        "parameters of createPrescription method",
+                activePrescriptionData.getPatientId(), patientData.getId());
         assertEquals("The created prescription data should have the same patient ID noted as the " +
-                "parameters of createPrescription method", prescriptionData.getDoctorId(), doctor.getId());
+                "parameters of createPrescription method", activePrescriptionData.getDoctorId(), doctorData.getId());
         assertEquals("Original prescription and loaded prescription have the same expiry date",
-                prescriptionData.getExpiryDate().compareTo(localExpiryDate), 0);
+                activePrescriptionData.getExpiryDate().compareTo(activeLocalExpiryDate), 0);
 
-        Prescription loadedPrescription = prescriptionDatabase.get(prescriptionData.getPrescriptionId());
+        Prescription loadedPrescription = prescriptionDatabase.get(activePrescriptionData.getPrescriptionId());
 
         /* Testing if the prescription object has been correctly added to the database by testing if the fields of the
         loaded patient are equal to the parameters of createPatient */
         assertEquals("The loaded prescription object should have the same header as the " +
-                "parameters of createPrescription method", loadedPrescription.getHeader(), header);
+                "parameters of createPrescription method", loadedPrescription.getHeader(), "bad");
         assertEquals("The loaded prescription object should have the same body as the " +
-                "parameters of createPrescription method", loadedPrescription.getBody(), body);
+                "parameters of createPrescription method", loadedPrescription.getBody(), "very unhealthy");
         assertEquals("The loaded prescription object should have the same patient ID noted as the " +
-                "parameters of createPrescription method", loadedPrescription.getPatientId(), patient.getId());
+                "parameters of createPrescription method", loadedPrescription.getPatientId(), patientData.getId());
         assertEquals("The loaded prescription object should have the same patient ID noted as the " +
-                "parameters of createPrescription method", prescriptionData.getDoctorId(), doctor.getId());
+                "parameters of createPrescription method", activePrescriptionData.getDoctorId(), doctorData.getId());
         assertEquals("The loaded prescription object should have the same expiry as the parameters of " +
-                        "createPrescription method", prescriptionData.getExpiryDate().compareTo(localExpiryDate),
-                0);
+                        "createPrescription method",
+                activePrescriptionData.getExpiryDate().compareTo(activeLocalExpiryDate), 0);
     }
 
     /**
@@ -189,37 +157,24 @@ public class PrescriptionManagerTests {
      */
     @Test(timeout = 1000)
     public void testRemovePrescription() {
-        LocalDate inactiveLocalExpiryDate = LocalDate.of(2021, 7, 1);
-        LocalDate activeLocalExpiryDate = LocalDate.of(2050, 7, 1);
-
-        Prescription originalPrescription1 = new
-                Prescription("medicine", "healthy", patient.getId(),
-                doctor.getId(), inactiveLocalExpiryDate);
-        Prescription originalPrescription2 = new
-                Prescription("bad", "very unhealthy", patient.getId(),
-                doctor.getId(), activeLocalExpiryDate);
-
-        prescriptionDatabase.add(originalPrescription1);
-        prescriptionDatabase.add(originalPrescription2);
-
         ArrayList<PrescriptionData> loadedPrescriptionList1 =
-                prescriptionManager.getAllPrescriptions(patient);
+                prescriptionManager.getAllPrescriptions(patientData);
 
         assertEquals("The array list should have a length of 2 before a prescription is removed ",
                 2, loadedPrescriptionList1.size());
 
-        prescriptionManager.removePrescription(new PrescriptionData(originalPrescription2));
+        prescriptionManager.removePrescription(activePrescriptionData);
 
         ArrayList<PrescriptionData> loadedPrescriptionList2 =
-                prescriptionManager.getAllPrescriptions(patient);
+                prescriptionManager.getAllPrescriptions(patientData);
 
         assertEquals("The array list should have a length of 1 after a prescription is removed ",
                 1, loadedPrescriptionList2.size());
 
-        prescriptionManager.removePrescription(new PrescriptionData(originalPrescription1));
+        prescriptionManager.removePrescription(inactivePrescriptionData);
 
         ArrayList<PrescriptionData> loadedPrescriptionList3 =
-                prescriptionManager.getAllPrescriptions(patient);
+                prescriptionManager.getAllPrescriptions(patientData);
 
         assertTrue("The array list should be empty after all prescriptions are removed",
                 loadedPrescriptionList3.isEmpty());
@@ -230,26 +185,15 @@ public class PrescriptionManagerTests {
      */
     @Test(timeout = 1000)
     public void testGetPatientsPrescriptionsWhenTheyHaveNone() {
-        PatientData patient2 = new PatientManager(originalDatabase).createPatient("test 5", "test4");
-
-        LocalDate inactiveLocalExpiryDate = LocalDate.of(2021, 7, 1);
-        LocalDate activeLocalExpiryDate = LocalDate.of(2050, 7, 1);
-
-        Prescription originalPrescription1 = new
-                Prescription("medicine", "healthy", patient.getId(),
-                doctor.getId(), inactiveLocalExpiryDate);
-        Prescription originalPrescription2 = new
-                Prescription("bad", "very unhealthy", patient.getId(),
-                doctor.getId(), activeLocalExpiryDate);
-
-        prescriptionDatabase.add(originalPrescription1);
-        prescriptionDatabase.add(originalPrescription2);
-
+        PatientData newPatientData = new PatientManager(originalDatabase).createPatient(
+                "new", "new");
         ArrayList<PrescriptionData> loadedPrescriptionList =
-                prescriptionManager.getAllPrescriptions(patient2);
+                prescriptionManager.getAllPrescriptions(newPatientData);
 
-        Assert.assertTrue("The list of this patient's prescriptions should be empty", loadedPrescriptionList.isEmpty());
+        Assert.assertTrue("The list of this patient's prescriptions should be empty",
+                loadedPrescriptionList.isEmpty());
     }
+
     /**
      * Deletes the temporary database folder used to store the database for tests after tests are done.
      */
@@ -257,4 +201,5 @@ public class PrescriptionManagerTests {
     public void after() {
         DeleteUtils.deleteDirectory(new File(databaseFolder.toString()));
     }
+
 }

--- a/test/PrescriptionManagerTests.java
+++ b/test/PrescriptionManagerTests.java
@@ -175,7 +175,7 @@ public class PrescriptionManagerTests {
     @Test(timeout = 1000)
     public void testGetPatientsPrescriptionsWhenTheyHaveNone() {
         PatientData newPatientData = new PatientManager(originalDatabase).createPatient(
-                "new", "new");
+                "newpatient", "123456789");
         ArrayList<PrescriptionData> loadedPrescriptionList =
                 prescriptionManager.getAllPrescriptions(newPatientData);
 

--- a/test/PrescriptionManagerTests.java
+++ b/test/PrescriptionManagerTests.java
@@ -23,12 +23,6 @@ import static org.junit.Assert.assertEquals;
  * Tests for the PrescriptionManager class.
  */
 public class PrescriptionManagerTests {
-    Database originalDatabase;
-    DataMapperGateway<Prescription> prescriptionDatabase;
-    PatientData patient;
-    DoctorData doctor;
-    PrescriptionManager prescriptionManager;
-
     /**
      * The variable representing the temporary folder where the databases used in these tests are stored until it is
      * deleted after the tests.

--- a/test/PrescriptionManagerTests.java
+++ b/test/PrescriptionManagerTests.java
@@ -54,17 +54,19 @@ public class PrescriptionManagerTests {
                 patientData, doctorData, inactiveLocalExpiryDate);
         activePrescriptionData = prescriptionManager.createPrescription("bad", "very unhealthy",
                 patientData, doctorData, activeLocalExpiryDate);
-
     }
 
     /**
-     * Tests getAllActivePrescription by inputting a valid active prescription, and ensuring the prescription in database
-     * is the same as the one returned.
+     * Tests getAllActivePrescription with a patient that has an active prescription, and ensuring the prescription
+     * in database is the same as the one returned.
      */
     @Test(timeout = 1000)
-    public void testGetPatientActivePrescriptionDataUsingActivePrescription() {
+    public void testGetPatientActivePrescriptionData() {
         ArrayList<PrescriptionData> loadedPrescriptionList =
                 prescriptionManager.getAllActivePrescriptions(patientData);
+
+        assertEquals("Since there is only one non-expired prescriptions, the ArrayList have a length of 1",
+                loadedPrescriptionList.size(), 1);
 
         PrescriptionData loadedPrescriptionData = loadedPrescriptionList.get(0);
 
@@ -86,18 +88,6 @@ public class PrescriptionManagerTests {
         assertEquals("Original prescription and loaded prescription have the same expiry date",
                 activePrescriptionData.getExpiryDate().compareTo(loadedPrescriptionData.
                         getExpiryDate()), 0);
-    }
-    /**
-     * Tests getAllActivePrescription by inputting an inactive prescription, and ensuring the is no prescription in the
-     * database.
-     */
-    @Test(timeout = 1000)
-    public void testGetPatientActivePrescriptionDataUsingInactivePrescription() {
-        ArrayList<PrescriptionData> loadedPrescriptionList =
-                prescriptionManager.getAllActivePrescriptions(patientData);
-
-        assertEquals("Since there is only one non expired prescriptions, the ArrayList have a length of 1",
-                loadedPrescriptionList.size(), 1);
     }
 
     /**

--- a/test/SecretaryManagerTests.java
+++ b/test/SecretaryManagerTests.java
@@ -24,7 +24,6 @@ public class SecretaryManagerTests {
      */
     @Rule
     public TemporaryFolder databaseFolder = new TemporaryFolder();
-
     private DataMapperGateway<Secretary> secretaryDatabase;
     private SecretaryManager secretaryManager;
     private SecretaryData secretaryData;
@@ -43,11 +42,10 @@ public class SecretaryManagerTests {
     }
 
     /**
-     * Tests createSecretary by ensuring that the values of the patient stored in the database are the same as the
-     * secretaryData returned from the function.
+     * Tests createSecretary by creating a secretary in the database using a valid and unused username.
      */
     @Test(timeout = 1000)
-    public void testCreateSecretaryValid() {
+    public void testCreateSecretaryValidUnused() {
         /* Testing if the return secretary data is valid by testing if the fields of are equal to the parameters of
         createSecretary */
         assertEquals("The created secretary data should have the same name as the parameters of " +
@@ -64,12 +62,22 @@ public class SecretaryManagerTests {
     }
 
     /**
-     * Tests create secretary with an invalid username and password that already exist in the database.
+     * Tests create secretary with a username that already exists in the database.
      */
     @Test(timeout = 1000)
-    public void testCreateSecretaryInvalid() {
+    public void testCreateSecretaryExistingUsername() {
         assertNull("creating a user with the same name and password already existing in the database " +
                 "should return null", secretaryManager.createSecretary(username, password));
+    }
+
+    /**
+     * Tests create secretary with a format that does pass the regex check.
+     */
+    @Test(timeout = 1000)
+    public void testCreateSecretaryInvalidFormat() {
+        assertThrows("creating a user with a non-alphanumeric username and a password shorter than 8 " +
+                "characters will return an illegal argument exception", IllegalArgumentException.class,
+                () -> secretaryManager.createSecretary("!!!", "123"));
     }
 
     /**
@@ -92,7 +100,6 @@ public class SecretaryManagerTests {
      */
     @Test(timeout = 1000)
     public void getUserData() {
-
         SecretaryData secretaryData1 = secretaryManager.getUserData(secretaryData.getUsername());
 
         /* Testing if the secretaryData and the original secretary are equal by testing whether all the fields of both

--- a/test/SecretaryManagerTests.java
+++ b/test/SecretaryManagerTests.java
@@ -77,9 +77,6 @@ public class SecretaryManagerTests {
      */
     @Test(timeout = 1000)
     public void testDeleteSecretary() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Secretary> secretaryDatabase = originalDatabase.getSecretaryDatabase();
-
         assertNotNull("A secretary object should be returned before it is deleted ",
                 secretaryDatabase.get(secretaryData.getId()));
 

--- a/test/SecretaryManagerTests.java
+++ b/test/SecretaryManagerTests.java
@@ -75,9 +75,15 @@ public class SecretaryManagerTests {
      */
     @Test(timeout = 1000)
     public void testCreateSecretaryInvalidFormat() {
-        assertThrows("creating a user with a non-alphanumeric username and a password shorter than 8 " +
-                "characters will return an illegal argument exception", IllegalArgumentException.class,
-                () -> secretaryManager.createSecretary("!!!", "123"));
+        assertThrows("creating a user with a non-alphanumeric username characters will return an illegal " +
+                        "argument exception", IllegalArgumentException.class,
+                () -> secretaryManager.createSecretary("newuser!", "123456789"));
+        assertThrows("creating a user with a username shorter than 6 characters will return an illegal " +
+                        "argument exception", IllegalArgumentException.class,
+                () -> secretaryManager.createSecretary("newu", "123456789"));
+        assertThrows("creating a user with a password shorter than 8 characters will return an illegal " +
+                        "argument exception", IllegalArgumentException.class,
+                () -> secretaryManager.createSecretary("newuser1", "1234567"));
     }
 
     /**

--- a/test/SecretaryManagerTests.java
+++ b/test/SecretaryManagerTests.java
@@ -1,294 +1,227 @@
-import dataBundles.ContactData;
 import dataBundles.SecretaryData;
 import database.DataMapperGateway;
 import database.Database;
 import entities.Secretary;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import useCases.SecretaryManager;
 import utilities.DeleteUtils;
 import java.io.File;
-import java.time.LocalDate;
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertNull;
 
+/**
+ * Class of unit tests for SecretaryManager use case class.
+ */
 public class SecretaryManagerTests {
 
+    /**
+     * The variable representing the temporary folder where the databases used in these tests are stored until it is
+     * deleted after the tests.
+     */
     @Rule
     public TemporaryFolder databaseFolder = new TemporaryFolder();
 
+    private DataMapperGateway<Secretary> secretaryDatabase;
+    private SecretaryManager secretaryManager;
+    private SecretaryData secretaryData;
+    /**
+     * Initializes the variables used by all the tests before each unit test.
+     */
+    @Before
+    public void before(){
+        Database originalDatabase = new Database(databaseFolder.toString());
+        secretaryDatabase = originalDatabase.getSecretaryDatabase();
+        secretaryManager = new SecretaryManager(originalDatabase);
+        secretaryData = secretaryManager.createSecretary("jeff", "123");
+    }
+
+    /**
+     * Tests createSecretary by ensuring that the values of the patient stored in the database are the same as the
+     * secretaryData returned from the function.
+     */
     @Test(timeout = 1000)
     public void testCreateSecretaryValid() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Secretary> secretaryDatabase = originalDatabase.getSecretaryDatabase();
-
-        String username = "jeff";
-        String password = "123";
-        LocalDate birthday = LocalDate.of(2022, 1, 1);
-        ContactData contactData = new ContactData("jeff", "jeff@gmail.com",
-                "12345678", "jeff street", birthday, "jim",
-                "jim@gmail.com", "87654321",
-                "father");
-
-        SecretaryManager secretaryManager = new SecretaryManager(originalDatabase);
-
-        SecretaryData secretaryData = secretaryManager.createSecretary(username, password);
-
         /* Testing if the return secretary data is valid by testing if the fields of are equal to the parameters of
         createSecretary */
         assertEquals("The created secretary data should have the same name as the parameters of " +
-                "createSecretary method", secretaryData.getUsername(), username);
+                "createSecretary method", secretaryData.getUsername(), "jeff");
 
         Secretary loadedSecretary = secretaryDatabase.get(secretaryData.getId());
 
         /* Testing if the secretary object has been correctly added to the database by testing if the fields of the loaded
         secretary are equal to the parameters of createSecretary */
         assertEquals("Original secretary and loaded secretary should share the same unique username",
-                loadedSecretary.getUsername(), username);
+                loadedSecretary.getUsername(), "jeff");
         assertTrue("Original secretary and loaded secretary should share the same password",
-                loadedSecretary.comparePassword(password));
+                loadedSecretary.comparePassword("123"));
     }
+
+    /**
+     * Tests create secretary with an invalid username and password that already exist in the database.
+     */
     @Test(timeout = 1000)
     public void testCreateSecretaryInvalid() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Secretary> secretaryDatabase = originalDatabase.getSecretaryDatabase();
-
-        String username = "jeff";
-        String password = "123";
-        LocalDate birthday = LocalDate.of(2022, 1, 1);
-        ContactData contactData = new ContactData("jeff", "jeff@gmail.com",
-                "12345678", "jeff street", birthday, "jim",
-                "jim@gmail.com", "87654321",
-                "father");
-
-        SecretaryManager secretaryManager = new SecretaryManager(originalDatabase);
-
-        SecretaryData secretaryData = secretaryManager.createSecretary(username, password);
-
         assertNull("creating a user with the same name and password already existing in the database " +
-                "should return null", secretaryManager.createSecretary(username, password));
+                "should return null", secretaryManager.createSecretary("jeff", "123"));
     }
 
+    /**
+     * Tests a valid use of deleteSecretary.
+     */
     @Test(timeout = 1000)
     public void testDeleteSecretary() {
         Database originalDatabase = new Database(databaseFolder.toString());
         DataMapperGateway<Secretary> secretaryDatabase = originalDatabase.getSecretaryDatabase();
 
-        Secretary secretary = new
-                Secretary("jeff", "123", 123456789);
-
-        SecretaryManager secretaryManager = new SecretaryManager(originalDatabase);
-
-        Integer secretaryID = secretaryDatabase.add(secretary);
-
         assertNotNull("A secretary object should be returned before it is deleted ",
-                secretaryDatabase.get(secretaryID));
+                secretaryDatabase.get(secretaryData.getId()));
 
-        secretaryManager.deleteUser(secretary.getUsername());
+        secretaryManager.deleteUser(secretaryData.getUsername());
 
         assertNull("A secretary object should not be returned after it is deleted ",
-                secretaryDatabase.get(secretaryID));
+                secretaryDatabase.get(secretaryData.getId()));
     }
+
+    /**
+     * Tests getUserData by ensuring that the values from the secretary stored in the database are the same as the values
+     * stored in the secretaryData returned from the function.
+     */
     @Test(timeout = 1000)
     public void getUserData() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Secretary> secretaryDatabase = originalDatabase.getSecretaryDatabase();
 
-        Secretary secretary = new
-                Secretary("jeff", "123", 123456789);
-
-        SecretaryManager secretaryManager = new SecretaryManager(originalDatabase);
-
-        Integer secretaryID = secretaryDatabase.add(secretary);
-
-        SecretaryData secretaryData = secretaryManager.getUserData(secretary.getUsername());
+        SecretaryData secretaryData1 = secretaryManager.getUserData(secretaryData.getUsername());
 
         /* Testing if the secretaryData and the original secretary are equal by testing whether all the fields of both
         objects are equal */
         assertEquals("secretary and secretaryData should share the same Id",
-                secretary.getId(), secretaryData.getId());
+                secretaryData1.getId(), secretaryData.getId());
         assertEquals("secretary and secretaryData should share the same unique username",
-                secretary.getUsername(), secretaryData.getUsername());
+                secretaryData1.getUsername(), secretaryData.getUsername());
         assertEquals("secretary and secretaryData should share the same contact information",
-                secretary.getContactInfoId(), secretaryData.getContactInfoId());
-        assertTrue("secretary and secretaryData should share the same password",
-                secretary.comparePassword("123"));
+                secretaryData1.getContactInfoId(), secretaryData.getContactInfoId());
     }
+
+    /**
+     * Tests an invalid use of getUserData when a username that does not exist in the database is inputted.
+     */
     @Test(timeout = 1000)
     public void getUserDataInvalid() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        SecretaryManager secretaryManager = new SecretaryManager(originalDatabase);
-
         assertNull("trying to get user data of a user that doesn't exist should return null",
                 secretaryManager.getUserData("jim"));
 
     }
+
+    /**
+     * Tests deleteUserByData but specifically with secretary data.
+     */
     @Test(timeout = 1000)
     public void testDeleteSecretaryByData() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Secretary> secretaryDatabase = originalDatabase.getSecretaryDatabase();
-
-        Secretary secretary = new
-                Secretary("jeff", "123", 123456789);
-
-        SecretaryManager secretaryManager = new SecretaryManager(originalDatabase);
-
-        Integer secretaryID = secretaryDatabase.add(secretary);
-        SecretaryData userdata = secretaryManager.getUserData(secretary.getUsername());
-
         assertNotNull("A secretary object should be returned before it is deleted ",
-                secretaryDatabase.get(secretaryID));
+                secretaryDatabase.get(secretaryData.getId()));
 
-        secretaryManager.deleteUserByData(userdata);
+        secretaryManager.deleteUserByData(secretaryData);
 
         assertNull("A secretary object should not be returned after it is deleted by data",
-                secretaryDatabase.get(secretaryID));
+                secretaryDatabase.get(secretaryData.getId()));
     }
 
+    /**
+     * Tests changeUserPassword specifically with secretary data.
+     */
     @Test(timeout = 1000)
     public void testChangeUserPassword() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Secretary> secretaryDatabase = originalDatabase.getSecretaryDatabase();
-
-        Secretary secretary = new
-                Secretary("jeff", "123", 123456789);
-
-        SecretaryManager secretaryManager = new SecretaryManager(originalDatabase);
-
-        Integer secretaryID = secretaryDatabase.add(secretary);
-        SecretaryData secretaryData = new SecretaryData(secretary);
-
         assertTrue("The password should remain the same before the change ",
-                secretaryDatabase.get(secretaryID).comparePassword("123"));
+                secretaryDatabase.get(secretaryData.getId()).comparePassword("123"));
 
         secretaryManager.changeUserPassword(secretaryData, "456");
 
         assertTrue("The secretary object should have the same password as we inputted into the parameters " +
                         "of the changeUserPassword method ",
-                secretaryDatabase.get(secretaryID).comparePassword("456"));
+                secretaryDatabase.get(secretaryData.getId()).comparePassword("456"));
     }
 
+    /**
+     * Tests getUser but specifically with secretary data, and ensure the secretary stored in the database and the returned
+     * loadedSecretary.
+     */
     @Test(timeout = 1000)
     public void testGetSecretary() {
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Secretary> secretaryDatabase = originalDatabase.getSecretaryDatabase();
-
-        Secretary originalSecretary = new
-                Secretary("jeff", "123", 123456789);
-
-        SecretaryManager secretaryManager = new SecretaryManager(originalDatabase);
-
-        Integer secretaryID = secretaryDatabase.add(originalSecretary);
-
-        assertEquals("Original secretary should share the same ID from the database",
-                originalSecretary.getId(), secretaryID);
-
-        Secretary loadedSecretary = secretaryDatabase.get(originalSecretary.getId());
+        Secretary loadedSecretary = secretaryDatabase.get(secretaryData.getId());
         /* Testing if the loaded secretary and the original secretary are equal by testing whether all the fields of both
         objects are equal */
         assertEquals("Original secretary and loaded secretary should share the same Id",
-                originalSecretary.getId(), loadedSecretary.getId());
+                secretaryData.getId(), loadedSecretary.getId());
         assertEquals("Original secretary and loaded secretary should share the same unique username",
-                originalSecretary.getUsername(), loadedSecretary.getUsername());
+                secretaryData.getUsername(), loadedSecretary.getUsername());
         assertEquals("Original secretary and loaded secretary should share the same contact information",
-                originalSecretary.getContactInfoId(), loadedSecretary.getContactInfoId());
+                secretaryData.getContactInfoId(), loadedSecretary.getContactInfoId());
         assertTrue("Original secretary and loaded secretary should share the same password",
                 loadedSecretary.comparePassword("123"));
     }
 
+    /**
+     * Tests doesUserExist with the secretary username inputted.
+     */
     @Test(timeout = 1000)
     public void testDoesUserExist(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Secretary> secretaryDatabase = originalDatabase.getSecretaryDatabase();
-
-        Secretary secretary = new
-                Secretary("jeff", "123", 123456789);
-
-        SecretaryManager secretaryManager = new SecretaryManager(originalDatabase);
-        Integer secretaryId = secretaryDatabase.add(secretary);
-
         assertNotNull("A secretary object should be returned when added to the database",
-                secretaryDatabase.get(secretaryId));
+                secretaryDatabase.get(secretaryData.getId()));
         assertTrue("DoesUserExist should return true since the secretary is stored in the database",
-                secretaryManager.doesUserExist(secretary.getUsername()));
+                secretaryManager.doesUserExist(secretaryData.getUsername()));
     }
+
+    /**
+     * Tests does user exist with an invalid username inputted.
+     */
     @Test(timeout = 1000)
     public void testUserDoesNotExist(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Secretary> secretaryDatabase = originalDatabase.getSecretaryDatabase();
-
-        Secretary secretary = new
-                Secretary("jeff", "123", 123456789);
-
-        SecretaryManager secretaryManager = new SecretaryManager(originalDatabase);
-        Integer secretaryId = secretaryDatabase.add(secretary);
-
         assertFalse("DoesUserExist should return false if there is no account stored in the database with the" +
-                        "inputted username",
-                secretaryManager.doesUserExist("jim"));
+                        "inputted username", secretaryManager.doesUserExist("jim"));
     }
+
+    /**
+     * Tests a valid use of canSignIn with a secretary's username and password.
+     */
     @Test(timeout = 1000)
     public void testCanSignInValid(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Secretary> secretaryDatabase = originalDatabase.getSecretaryDatabase();
-
-        Secretary secretary = new
-                Secretary("jeff", "123", 123456789);
-
-        SecretaryManager secretaryManager = new SecretaryManager(originalDatabase);
-        Integer secretaryId = secretaryDatabase.add(secretary);
-
         assertTrue("canSignIn should return true if given a username and password to an account in the " +
                 "database", secretaryManager.canSignIn("jeff", "123"));
     }
+
+    /**
+     * Tests an invalid use of canSignIn with a secretary's username and password that does not exist in the database.
+     */
     @Test(timeout = 1000)
     public void testCanSignInInvalid(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Secretary> secretaryDatabase = originalDatabase.getSecretaryDatabase();
-
-        Secretary secretary = new
-                Secretary("jeff", "123", 123456789);
-
-        SecretaryManager secretaryManager = new SecretaryManager(originalDatabase);
-        Integer secretaryId = secretaryDatabase.add(secretary);
-
         assertFalse("canSignIn should return false if given a username and password not linked to an account" +
                 "in the database", secretaryManager.canSignIn("jim", "password"));
     }
+
+    /**
+     * Tests signIn with an existing patient account.
+     */
     @Test(timeout = 1000)
     public void testSignInExistingAccount(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Secretary> secretaryDatabase = originalDatabase.getSecretaryDatabase();
-
-        Secretary secretary = new
-                Secretary("jeff", "123", 123456789);
-
-        SecretaryManager secretaryManager = new SecretaryManager(originalDatabase);
-        Integer secretaryId = secretaryDatabase.add(secretary);
-        SecretaryData secretaryData = secretaryManager.getUserData(secretary.getUsername());
-
         assertEquals("A correct account detail sign in should return the respective secretaryData",
-                secretaryManager.signIn(secretary.getUsername(), "123").getId(), secretaryData.getId());
+                secretaryManager.signIn(secretaryData.getUsername(), "123").getId(), secretaryData.getId());
     }
 
+    /**
+     * Tests an invalid use of signIn with a non-existing account.
+     */
     @Test(timeout = 1000)
     public void testSignInNonExistingAccount(){
-        Database originalDatabase = new Database(databaseFolder.toString());
-        DataMapperGateway<Secretary> secretaryDatabase = originalDatabase.getSecretaryDatabase();
-
-        Secretary secretary = new
-                Secretary("jeff", "123", 123456789);
-
-        SecretaryManager secretaryManager = new SecretaryManager(originalDatabase);
-        Integer secretaryId = secretaryDatabase.add(secretary);
-        SecretaryData secretaryData = secretaryManager.getUserData(secretary.getUsername());
-
         assertNull("an incorrect account detail sign in should return null", secretaryManager.signIn("jim",
                 "password"));
     }
 
+    /**
+     * Deletes the temporary database folder used to store the database for tests after tests are done.
+     */
     @After
     public void after() {
         DeleteUtils.deleteDirectory(new File(databaseFolder.toString()));

--- a/test/SecretaryManagerTests.java
+++ b/test/SecretaryManagerTests.java
@@ -28,6 +28,9 @@ public class SecretaryManagerTests {
     private DataMapperGateway<Secretary> secretaryDatabase;
     private SecretaryManager secretaryManager;
     private SecretaryData secretaryData;
+    private final String username = "mynamejeff";
+    private final String password = "123456789";
+    
     /**
      * Initializes the variables used by all the tests before each unit test.
      */
@@ -36,7 +39,7 @@ public class SecretaryManagerTests {
         Database originalDatabase = new Database(databaseFolder.toString());
         secretaryDatabase = originalDatabase.getSecretaryDatabase();
         secretaryManager = new SecretaryManager(originalDatabase);
-        secretaryData = secretaryManager.createSecretary("jeff", "123");
+        secretaryData = secretaryManager.createSecretary(username, password);
     }
 
     /**
@@ -48,16 +51,16 @@ public class SecretaryManagerTests {
         /* Testing if the return secretary data is valid by testing if the fields of are equal to the parameters of
         createSecretary */
         assertEquals("The created secretary data should have the same name as the parameters of " +
-                "createSecretary method", secretaryData.getUsername(), "jeff");
+                "createSecretary method", secretaryData.getUsername(), username);
 
         Secretary loadedSecretary = secretaryDatabase.get(secretaryData.getId());
 
-        /* Testing if the secretary object has been correctly added to the database by testing if the fields of the loaded
-        secretary are equal to the parameters of createSecretary */
+        /* Testing if the secretary object has been correctly added to the database by testing if the fields of the
+        loaded secretary are equal to the parameters of createSecretary */
         assertEquals("Original secretary and loaded secretary should share the same unique username",
-                loadedSecretary.getUsername(), "jeff");
+                loadedSecretary.getUsername(), username);
         assertTrue("Original secretary and loaded secretary should share the same password",
-                loadedSecretary.comparePassword("123"));
+                loadedSecretary.comparePassword(password));
     }
 
     /**
@@ -66,7 +69,7 @@ public class SecretaryManagerTests {
     @Test(timeout = 1000)
     public void testCreateSecretaryInvalid() {
         assertNull("creating a user with the same name and password already existing in the database " +
-                "should return null", secretaryManager.createSecretary("jeff", "123"));
+                "should return null", secretaryManager.createSecretary(username, password));
     }
 
     /**
@@ -111,7 +114,7 @@ public class SecretaryManagerTests {
     @Test(timeout = 1000)
     public void getUserDataInvalid() {
         assertNull("trying to get user data of a user that doesn't exist should return null",
-                secretaryManager.getUserData("jim"));
+                secretaryManager.getUserData("jimhalpert"));
 
     }
 
@@ -135,7 +138,7 @@ public class SecretaryManagerTests {
     @Test(timeout = 1000)
     public void testChangeUserPassword() {
         assertTrue("The password should remain the same before the change ",
-                secretaryDatabase.get(secretaryData.getId()).comparePassword("123"));
+                secretaryDatabase.get(secretaryData.getId()).comparePassword(password));
 
         secretaryManager.changeUserPassword(secretaryData, "456");
 
@@ -160,7 +163,7 @@ public class SecretaryManagerTests {
         assertEquals("Original secretary and loaded secretary should share the same contact information",
                 secretaryData.getContactInfoId(), loadedSecretary.getContactInfoId());
         assertTrue("Original secretary and loaded secretary should share the same password",
-                loadedSecretary.comparePassword("123"));
+                loadedSecretary.comparePassword(password));
     }
 
     /**
@@ -180,7 +183,7 @@ public class SecretaryManagerTests {
     @Test(timeout = 1000)
     public void testUserDoesNotExist(){
         assertFalse("DoesUserExist should return false if there is no account stored in the database with the" +
-                        "inputted username", secretaryManager.doesUserExist("jim"));
+                        "inputted username", secretaryManager.doesUserExist("jimhalpert"));
     }
 
     /**
@@ -189,7 +192,7 @@ public class SecretaryManagerTests {
     @Test(timeout = 1000)
     public void testCanSignInValid(){
         assertTrue("canSignIn should return true if given a username and password to an account in the " +
-                "database", secretaryManager.canSignIn("jeff", "123"));
+                "database", secretaryManager.canSignIn(username, password));
     }
 
     /**
@@ -198,7 +201,7 @@ public class SecretaryManagerTests {
     @Test(timeout = 1000)
     public void testCanSignInInvalid(){
         assertFalse("canSignIn should return false if given a username and password not linked to an account" +
-                "in the database", secretaryManager.canSignIn("jim", "password"));
+                "in the database", secretaryManager.canSignIn("jimhalpert", "password"));
     }
 
     /**
@@ -207,7 +210,7 @@ public class SecretaryManagerTests {
     @Test(timeout = 1000)
     public void testSignInExistingAccount(){
         assertEquals("A correct account detail sign in should return the respective secretaryData",
-                secretaryManager.signIn(secretaryData.getUsername(), "123").getId(), secretaryData.getId());
+                secretaryManager.signIn(secretaryData.getUsername(), password).getId(), secretaryData.getId());
     }
 
     /**
@@ -215,8 +218,8 @@ public class SecretaryManagerTests {
      */
     @Test(timeout = 1000)
     public void testSignInNonExistingAccount(){
-        assertNull("an incorrect account detail sign in should return null", secretaryManager.signIn("jim",
-                "password"));
+        assertNull("an incorrect account detail sign in should return null", secretaryManager.signIn(
+                "jimhalpert", "password"));
     }
 
     /**


### PR DESCRIPTION
We stored the back command in the terminal controller but it was only used by the controllers associated with menus (e.g. doctor loaded patient, clinic, contact, etc.). So, in order to avoid code smells and make our code more extensible, I implemented a menu controller to abstract these classes. There was also a command that only menus that dealt with loaded patients used, so I created a child abstract class of the menu class that deals with this called menu loaded patient controller. This allows the code to be expanded to many different kinds of menus and loaded patient menus without having to repeat code, especially if we add more commands specific to menus.