### PR TITLE
refactor: implemented menu controller and menu loaded patient controller abstract classes that store commands specific to menus

### DIFF
--- a/src/controllers/AdminUserManagementController.java
+++ b/src/controllers/AdminUserManagementController.java
@@ -12,9 +12,8 @@ import java.util.LinkedHashMap;
 /**
  * Controller class that handles the creation and deletion of users by an admin.
  */
-public class AdminUserManagementController extends TerminalController {
+public class AdminUserManagementController extends MenuController {
 
-    private final AdminController previousController;
     private final AdminData adminData;
     private final AdminScreenView adminScreenView = new AdminScreenView();
     private final PatientManager patientManager;
@@ -31,8 +30,7 @@ public class AdminUserManagementController extends TerminalController {
      * @param adminData AdminData - a data containing the ID and attributes of the current loaded admin user.
      */
     public AdminUserManagementController(Context context, AdminController previousController, AdminData adminData) {
-        super(context);
-        this.previousController = previousController;
+        super(context, previousController);
         this.adminData = adminData;
         this.patientManager = new PatientManager(getDatabase());
         this.secretaryManager = new SecretaryManager(getDatabase());
@@ -58,7 +56,6 @@ public class AdminUserManagementController extends TerminalController {
     @Override
     public LinkedHashMap<String, Command> AllCommands (){
         LinkedHashMap<String, Command> commands = new LinkedHashMap<>();
-        commands.put("back", Back(previousController));
         commands.put("create admin", CreateAdmin());
         commands.put("create secretary", CreateSecretary());
         commands.put("create doctor", CreateDoctor());

--- a/src/controllers/ClinicController.java
+++ b/src/controllers/ClinicController.java
@@ -11,11 +11,10 @@ import java.util.LinkedHashMap;
 /**
  * Controller class that processes the commands that an admin performs on a clinic's information.
  */
-public class ClinicController extends TerminalController {
+public class ClinicController extends MenuController {
 
     private final ClinicScreenView clinicScreenView;
     private final ClinicManager clinicManager;
-    private final UserController<Admin> previousController;
 
 
     /**
@@ -26,10 +25,9 @@ public class ClinicController extends TerminalController {
      *                           clinic controller object.
      */
     public ClinicController(Context context, UserController<Admin> previousController) {
-        super(context);
+        super(context, previousController);
         this.clinicManager = new ClinicManager(getDatabase());
         this.clinicScreenView = new ClinicScreenView();
-        this.previousController = previousController;
     }
 
     @Override
@@ -51,7 +49,6 @@ public class ClinicController extends TerminalController {
         commands.put("change clinic address", ChangeClinicAddress());
         commands.put("change clinic hours", ChangeClinicHours());
         commands.put("remove clinic hours", RemoveClinicHours());
-        commands.put("back", Back(previousController));
         commands.putAll(super.AllCommands());
         return commands;
     }

--- a/src/controllers/ContactController.java
+++ b/src/controllers/ContactController.java
@@ -10,12 +10,11 @@ import java.util.LinkedHashMap;
 /**
  * Controller class that processes the commands that a user performs on their contact information.
  */
-public class ContactController extends TerminalController {
+public class ContactController extends MenuController {
 
     private final ContactData contactData;
     private final ContactScreenView contactScreenView;
     private final ContactManager contactManager;
-    private final UserController<?> previousController;
 
     /**
      * Creates a contact controller object that handles the commands a user performs on their contact information.
@@ -28,8 +27,7 @@ public class ContactController extends TerminalController {
      */
     public ContactController(Context context, UserController<?> previousController,
                              ContactData contactData) {
-        super(context);
-        this.previousController = previousController;
+        super(context, previousController);
         this.contactData = contactData;
         this.contactManager = new ContactManager(getDatabase());
         this.contactScreenView = new ContactScreenView();
@@ -57,7 +55,6 @@ public class ContactController extends TerminalController {
         commands.put("change emergency contact email", ChangeEmergencyContactEmail());
         commands.put("change emergency contact phone number", ChangeEmergencyContactPhoneNumber());
         commands.put("change emergency contact relationship", ChangeEmergencyContactRelationship());
-        commands.put("back", Back(previousController));
         commands.putAll(super.AllCommands());
         return commands;
     }

--- a/src/controllers/DoctorLoadedPatientController.java
+++ b/src/controllers/DoctorLoadedPatientController.java
@@ -13,13 +13,12 @@ import java.util.LinkedHashMap;
 /**
  * Controller class that process the commands a doctor would use on a specific patient that they loaded.
  */
-public class DoctorLoadedPatientController extends TerminalController {
+public class DoctorLoadedPatientController extends MenuLoadedPatientController {
 
     private final PatientData patientData;
     private final DoctorData doctorData;
     private final PrescriptionManager prescriptionManager;
     private final DoctorScreenView doctorScreenView = new DoctorScreenView();
-    private final DoctorController previousController;
     private final ReportManager reportManager;
     private final DoctorManager doctorManager;
     private final ContactManager contactManager;
@@ -37,10 +36,9 @@ public class DoctorLoadedPatientController extends TerminalController {
      */
     public DoctorLoadedPatientController(Context context, DoctorController previousController, DoctorData doctorData,
                                          PatientData patientData) {
-        super(context);
+        super(context, previousController);
         this.patientData = patientData;
         this.doctorData = doctorData;
-        this.previousController = previousController;
         this.prescriptionManager = new PrescriptionManager(getDatabase());
         this.reportManager = new ReportManager(getDatabase());
         this.doctorManager = new DoctorManager(getDatabase());
@@ -58,15 +56,16 @@ public class DoctorLoadedPatientController extends TerminalController {
     public LinkedHashMap<String, Command> AllCommands() {
         PrescriptionListCommands prescriptionListCommands = new PrescriptionListCommands(getDatabase(), patientData);
         LinkedHashMap<String, Command> commands = new LinkedHashMap<>();
-        commands.put("unload patient", Back(previousController));
-        commands.put("back", Back(previousController));
         commands.put("view appointments", ViewPatientAppointments());
         commands.put("view reports", ViewPatientReports());
         commands.put("create report", CreatePatientReport());
         commands.put("delete report", DeletePatientReport());
+
         prescriptionListCommands.AllCommands().forEach((x, y) -> commands.put("view " + x, y));
+
         commands.put("create prescription", CreatePatientPrescription());
         commands.put("delete prescription", DeletePatientPrescription());
+
         commands.putAll(super.AllCommands());
         return commands;
     }

--- a/src/controllers/MenuController.java
+++ b/src/controllers/MenuController.java
@@ -1,0 +1,37 @@
+package controllers;
+
+import java.util.LinkedHashMap;
+
+/**
+ * Controller class for processing commands that a user passes in while on a menu screen.
+ */
+abstract public class MenuController extends TerminalController {
+
+    private final UserController<?> previousController;
+
+    /**
+     * Creates a new controller for handling the state of when a user on a menu screen.
+     */
+    public MenuController(Context context, UserController<?> previousController) {
+        super(context);
+        this.previousController = previousController;
+    }
+
+    /**
+     * Creates a Linked hashmap of all string representations of menu commands mapped to the method that each
+     * command calls.
+     * @return LinkedHashMap<String, Command> - ordered HashMap of strings mapped to their respective menu commands.
+     */
+    @Override
+    public LinkedHashMap<String, Command> AllCommands() {
+        LinkedHashMap<String, Command> commands = new LinkedHashMap<>();
+        commands.put("back", Back(previousController));
+        commands.putAll(super.AllCommands());
+        return commands;
+    }
+
+    protected Command Back(TerminalController previousController) {
+        return (x) -> changeCurrentController(previousController);
+    }
+
+}

--- a/src/controllers/MenuLoadedPatientController.java
+++ b/src/controllers/MenuLoadedPatientController.java
@@ -1,0 +1,34 @@
+package controllers;
+
+import java.util.LinkedHashMap;
+
+/**
+ * Controller class for processing commands that a user passes in while having loaded a patient.
+ */
+abstract public class MenuLoadedPatientController extends controllers.MenuController {
+
+    private final UserController<?> previousController;
+
+    /**
+     * Creates a new controller for handling the state of when a user has loaded a patient.
+     */
+    public MenuLoadedPatientController(Context context, UserController<?> previousController) {
+        super(context, previousController);
+        this.previousController = previousController;
+    }
+
+    /**
+     * Creates a Linked hashmap of all string representations of menu loaded patient commands mapped to the method that
+     * each command calls.
+     * @return LinkedHashMap<String, Command> - ordered HashMap of strings mapped to their respective menu loaded
+     * patient commands.
+     */
+    @Override
+    public LinkedHashMap<String, Command> AllCommands() {
+        LinkedHashMap<String, Command> commands = new LinkedHashMap<>();
+        commands.put("unload patient", Back(previousController));
+        commands.putAll(super.AllCommands());
+        return commands;
+    }
+
+}

--- a/src/controllers/SecretaryLoadedPatientController.java
+++ b/src/controllers/SecretaryLoadedPatientController.java
@@ -20,30 +20,27 @@ import java.util.stream.Collectors;
 /**
  * Controller class that process the commands a secretary would use on a specific patient that they loaded.
  */
-public class SecretaryLoadedPatientController extends TerminalController {
+public class SecretaryLoadedPatientController extends MenuLoadedPatientController {
 
     private final PatientData patientData;
-    private final SecretaryController previousController;
     private final PatientManager patientManager;
     private final SecretaryScreenView secretaryScreenView = new SecretaryScreenView();
     private final AppointmentManager appointmentManager;
     private final ContactManager contactManager;
     private final DoctorManager doctorManager;
-
     private final TimeUtils timeUtils = new TimeUtils();
 
     /**
      * Creates a new controller for handling the state of the program when a doctor has loaded a specific patient.
      * @param context Context - a reference to the context object, which stores the current controller and allows for
      *                switching between controllers.
-     * @param secretaryController SecretaryController - the previous controller object, allowing you to easily go back.
+     * @param previousController SecretaryController - the previous controller object, allowing you to easily go back.
      * @param patientData PatientData - a data containing the ID and attributes of the current loaded
      *                    patient user.
      */
-    public SecretaryLoadedPatientController(Context context, SecretaryController secretaryController,
+    public SecretaryLoadedPatientController(Context context, SecretaryController previousController,
                                             PatientData patientData) {
-        super(context);
-        this.previousController = secretaryController;
+        super(context, previousController);
         this.patientData = patientData;
         this.patientManager = new PatientManager(getDatabase());
         this.appointmentManager = new AppointmentManager(getDatabase());
@@ -68,9 +65,6 @@ public class SecretaryLoadedPatientController extends TerminalController {
         commands.put("cancel appointment", CancelAppointment());
 
         prescriptionListCommands.AllCommands().forEach((x, y) -> commands.put("view " + x, y));
-
-        commands.put("unload patient", Back(previousController));
-        commands.put("back", Back(previousController));
 
         commands.putAll(super.AllCommands());
         return commands;


### PR DESCRIPTION
We stored the back command in the terminal controller but it was only used by the controllers associated with menus (e.g. doctor loaded patient, clinic, contact, etc.). So, in order to avoid code smells and make our code more extensible, I implemented a menu controller to abstract these classes. There was also a command that only menus that dealt with loaded patients used, so I created a child abstract class of the menu class that deals with this called menu loaded patient controller. This allows the code to be expanded to many different kinds of menus and loaded patient menus without having to repeat code, especially if we add more commands specific to menu screens.