### PR TITLE
refactor: make log manager's add log method take in user data

### DIFF
--- a/src/useCases/LogManager.java
+++ b/src/useCases/LogManager.java
@@ -27,12 +27,12 @@ public class LogManager {
 
     /**
      * Method for adding a log with some message to the user. Assumes userId is valid.
+     * @param userData UserData - data bundle of the user that the log will be attached to.
      * @param message String - message attached with to the log.
-     * @param userId Integer - id of the user that the log will be attached to.
      * @return LogData - data representing a log with the information passed in.
      */
-    public LogData addLog(String message, Integer userId){
-        Log log = new Log(userId, message);
+    public <T extends User> LogData addLog(UserData<T> userData, String message){
+        Log log = new Log(userData.getId(), message);
         logDatabase.add(log);
         return new LogData(log);
     }

--- a/src/useCases/UserManager.java
+++ b/src/useCases/UserManager.java
@@ -113,7 +113,7 @@ public abstract class UserManager<T extends User> {
     protected T signInHelper(String username, String password){
         if (canSignIn(username, password)) {
             T user = getUser(username);
-            logManager.addLog("signed in", user.getId());
+            logManager.addLog(getUserData(username), "signed in");
             return user;
         } else  {
             return null;

--- a/test/LogManagerTests.java
+++ b/test/LogManagerTests.java
@@ -1,10 +1,10 @@
 import dataBundles.LogData;
 import dataBundles.PatientData;
 import database.Database;
-import entities.Patient;
 import org.junit.*;
 import org.junit.rules.TemporaryFolder;
 import useCases.LogManager;
+import useCases.PatientManager;
 import utilities.DeleteUtils;
 import java.io.File;
 import java.util.ArrayList;
@@ -22,8 +22,7 @@ public class LogManagerTests {
     @Rule
     public TemporaryFolder databaseFolder = new TemporaryFolder();
     private Database database;
-    private Patient patient;
-    private Integer id;
+    private PatientData patientData;
     private LogManager logManager;
 
     /**
@@ -32,8 +31,7 @@ public class LogManagerTests {
     @Before
     public void before() {
         database = new Database(databaseFolder.toString());
-        patient = new Patient("danieldervy","123456789", 1);
-        id = database.getPatientDatabase().add(patient);
+        patientData = new PatientManager(database).createPatient("ryan12345", "123456789");
         logManager = new LogManager(database);
     }
 
@@ -42,10 +40,10 @@ public class LogManagerTests {
      */
     @Test
     public void testAddingNewLog() {
-        LogData logData = logManager.addLog("testing123", id);
-        Assert.assertEquals("Make sure that the right log is returned to the user", logData.getId(), id);
+        LogData logData = logManager.addLog(patientData, "testing123");
+        Assert.assertEquals("Make sure that the right log is returned to the user", logData.getId(), patientData.getId());
         Assert.assertNotNull("Make sure that log actually exists in the database",
-                database.getLogDatabase().get(id));
+                database.getLogDatabase().get(patientData.getId()));
     }
 
     /**
@@ -53,11 +51,11 @@ public class LogManagerTests {
      */
     @Test
     public void testGettingExistingUserLogs() {
-        LogData logA = logManager.addLog("testing1", id);
-        LogData logB = logManager.addLog("testing2", id);
-        LogData logC = logManager.addLog("testing3", id);
+        LogData logA = logManager.addLog(patientData, "testing1");
+        LogData logB = logManager.addLog(patientData, "testing2");
+        LogData logC = logManager.addLog(patientData, "testing3");
 
-        ArrayList<LogData> logArrayList = logManager.getUserLogs(new PatientData(patient));
+        ArrayList<LogData> logArrayList = logManager.getUserLogs(patientData);
         Assert.assertFalse("Check if logA is returned to the user as part of" +
                 "the arraylist returned when getting a user's logs", logArrayList.stream().
                 map(LogData::getUserId).
@@ -78,20 +76,6 @@ public class LogManagerTests {
                 isEmpty());
         Assert.assertEquals("Make sure there are only 3 logs in the arraylist. When paired with the other" +
                 "assert statements, the arraylist only consists of logA, logB, logC", 3, logArrayList.size());
-    }
-
-    /**
-     * Tests the log manager getter method that returns a user's logs with a non-existent user.
-     */
-    @Test
-    public void testGettingNonExistentUserLogs() {
-        logManager.addLog("testing1", 1);
-        logManager.addLog("testing2", 1);
-        logManager.addLog("testing3", 1);
-
-        ArrayList<LogData> logArrayList = logManager.getUserLogs(new PatientData(patient));
-        Assert.assertTrue("Since the user doesn't exist, we should get an empty arraylist",
-                logArrayList.isEmpty());
     }
 
     /**


### PR DESCRIPTION
The log manager's add log method seems to be taking in entity user IDs for no reason when it should be taking in user data bundles. All of our other creation methods use data bundles but this one seems to deviate from that convention for no reason. To fix this, I have refactored the log manager and user manager classes and fixed the log manager tests accordingly. 